### PR TITLE
feat: connects server to the source model layers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@ APP_USER_PASSWORD ?= "sourcescore"
 CNPG_VERSION ?= "1.25.1"
 K3D_VERSION ?= "v5.8.3"
 K3S_IMAGE_VERSION ?= "rancher/k3s:v1.31.8-k3s1-amd64"
-PG_HOST ?= "http://127.0.0.1"
+SERVER_HOST ?= "localhost"
 SUPER_USER_PASSWORD ?= "test_123"
 SERVER_PORT ?= 8070
 TEST_CLUSTER_NAME = "test-env"
 
 # common env setup
 export APP_USER_PASSWORD
-export PG_SERVER=$(PG_HOST):$(SERVER_PORT)
+export PG_HOST=$(SERVER_HOST)
 export PORT=$(SERVER_PORT)
 export SUPER_USER_PASSWORD
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"log/slog"
 	"os"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 
 	"source-score/pkg/api"
 	"source-score/pkg/conf"
+	"source-score/pkg/db/cnpg"
+	"source-score/pkg/domain/source"
 	"source-score/pkg/helpers"
 	apiServer "source-score/pkg/http"
 	"source-score/pkg/logger"
@@ -38,8 +43,20 @@ func main() {
 		},
 	}
 
+	// initialize the layers
+	dsn := fmt.Sprintf(
+		"host=%s user=%s password=%s dbname=%s port=5432 sslmode=disable TimeZone=Asia/Shanghai",
+		conf.Cfg.PgHost,
+		conf.AppUserName,
+		conf.Cfg.AppUserPassword,
+		conf.DbName,
+	)
+	dbClient := cnpg.NewClient(context.Background(), dsn, &gorm.Config{})
+	srcRepo := source.NewSourceRepository(context.Background(), dbClient)
+	srcSvc := source.NewSourceService(context.Background(), srcRepo)
+
 	server := gin.Default()
-	api.RegisterHandlersWithOptions(server, apiServer.NewRouter(), loggerOpts)
+	api.RegisterHandlersWithOptions(server, apiServer.NewRouter(context.Background(), srcSvc), loggerOpts)
 
 	err := server.Run()
 	if err != nil {

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -7,9 +7,14 @@ import (
 	"github.com/ilyakaznacheev/cleanenv"
 )
 
+const (
+	AppUserName = "sourcescore"
+	DbName      = "sourcescore"
+)
+
 type conf struct {
 	AppUserPassword   string `env:"APP_USER_PASSWORD" yaml:"APP_USER_PASSWORD" env-required:"true"`
-	PgServer          string `env:"PG_SERVER" yaml:"PG_SERVER" env-required:"true"`
+	PgHost            string `env:"PG_HOST" yaml:"PG_HOST" env-required:"true"`
 	Port              string `env:"PORT" yaml:"PORT" env-required:"true"`
 	SuperUserPassword string `env:"SUPER_USER_PASSWORD" yaml:"SUPER_USER_PASSWORD" env-required:"true"`
 }

--- a/pkg/conf/conf.yaml
+++ b/pkg/conf/conf.yaml
@@ -1,4 +1,4 @@
 APP_USER_PASSWORD: env-pwd
-PG_SERVER: env-server
+PG_HOST: env-host
 PORT: 8999
 SUPER_USER_PASSWORD: user-pwd

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -9,16 +9,16 @@ import (
 )
 
 const (
-	SamplePort   = "8099"
-	SamplePwd    = "sample-pwd"
-	SampleServer = "sample-server"
-	SampleSUPwd  = "super-pwd"
+	SamplePort  = "8099"
+	SamplePwd   = "sample-pwd"
+	SampleHost  = "sample-host"
+	SampleSUPwd = "super-pwd"
 )
 
 var _ = Describe("Conf Tests", func() {
 	When("dotenv path is not set", func() {
 		os.Setenv("APP_USER_PASSWORD", SamplePwd)
-		os.Setenv("PG_SERVER", SampleServer)
+		os.Setenv("PG_HOST", SampleHost)
 		os.Setenv("PORT", SamplePort)
 		os.Setenv("SUPER_USER_PASSWORD", SampleSUPwd)
 
@@ -27,7 +27,7 @@ var _ = Describe("Conf Tests", func() {
 			conf.LoadConfig()
 
 			Expect(conf.Cfg.AppUserPassword).To(BeEquivalentTo(SamplePwd))
-			Expect(conf.Cfg.PgServer).To(BeEquivalentTo(SampleServer))
+			Expect(conf.Cfg.PgHost).To(BeEquivalentTo(SampleHost))
 			Expect(conf.Cfg.Port).To(BeEquivalentTo(SamplePort))
 			Expect(conf.Cfg.SuperUserPassword).To(BeEquivalentTo(SampleSUPwd))
 		})
@@ -39,7 +39,7 @@ var _ = Describe("Conf Tests", func() {
 			conf.LoadConfig()
 
 			Expect(conf.Cfg.AppUserPassword).To(BeEquivalentTo("env-pwd"))
-			Expect(conf.Cfg.PgServer).To(BeEquivalentTo("env-server"))
+			Expect(conf.Cfg.PgHost).To(BeEquivalentTo("env-host"))
 			Expect(conf.Cfg.Port).To(BeEquivalentTo("8999"))
 			Expect(conf.Cfg.SuperUserPassword).To(BeEquivalentTo("user-pwd"))
 		})

--- a/pkg/db/cnpg/client.go
+++ b/pkg/db/cnpg/client.go
@@ -12,11 +12,11 @@ type Client struct {
 	DB *gorm.DB
 }
 
-func NewClient(ctx context.Context, dbURL string, config *gorm.Config) *Client {
+func NewClient(ctx context.Context, dsn string, config *gorm.Config) *Client {
 	client := new(Client)
-	DB, err := gorm.Open(postgres.Open(dbURL), config)
+	DB, err := gorm.Open(postgres.Open(dsn), config)
 	if err != nil {
-		log.Fatalf("failed to open connection with database:%s :: %s", dbURL, err)
+		log.Fatalf("failed to open connection with database: %s", err)
 	}
 
 	client.DB = DB

--- a/pkg/domain/source/source_repository.go
+++ b/pkg/domain/source/source_repository.go
@@ -11,8 +11,8 @@ import (
 	"source-score/pkg/db/cnpg"
 )
 
-//go:generate go tool counterfeiter . SourceRepoInterface
-type SourceRepoInterface interface {
+//go:generate go tool counterfeiter . SourceRepository
+type SourceRepository interface {
 	DeleteSourceByUriDigest(ctx context.Context, source *api.Source) error
 	GetSourceByUriDigest(ctx context.Context, uriDigest string) (*api.Source, error)
 	PostSource(ctx context.Context, sourceInput *api.SourceInput) error
@@ -23,7 +23,7 @@ type sourceRepository struct {
 	client *cnpg.Client
 }
 
-func NewSourceRepository(ctx context.Context, client *cnpg.Client) *sourceRepository {
+func NewSourceRepository(ctx context.Context, client *cnpg.Client) SourceRepository {
 	return &sourceRepository{
 		client: client,
 	}

--- a/pkg/domain/source/source_service.go
+++ b/pkg/domain/source/source_service.go
@@ -13,10 +13,10 @@ type SourceService interface {
 }
 
 type sourceService struct {
-	sourceRepo SourceRepoInterface
+	sourceRepo SourceRepository
 }
 
-func NewSourceService(ctx context.Context, sourceRepo SourceRepoInterface) *sourceService {
+func NewSourceService(ctx context.Context, sourceRepo SourceRepository) SourceService {
 	return &sourceService{
 		sourceRepo: sourceRepo,
 	}

--- a/pkg/domain/source/source_suite_test.go
+++ b/pkg/domain/source/source_suite_test.go
@@ -26,13 +26,13 @@ var (
 	err                error
 	sampleSource1      api.Source
 	sampleSourceInput1 api.SourceInput
-	sourceRepo         source.SourceRepoInterface
+	sourceRepo         source.SourceRepository
 	sourceSvc          source.SourceService
 	testDB             *gorm.DB
 	updatedSource      api.Source
 
 	// fakes
-	fakeSourceRepo = sourcefakes.FakeSourceRepoInterface{}
+	fakeSourceRepo = sourcefakes.FakeSourceRepository{}
 )
 
 func TestSource(t *testing.T) {

--- a/pkg/domain/source/sourcefakes/fake_source_repo_interface.go
+++ b/pkg/domain/source/sourcefakes/fake_source_repo_interface.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 )
 
-type FakeSourceRepoInterface struct {
+type FakeSourceRepository struct {
 	DeleteSourceByUriDigestStub        func(context.Context, *api.Source) error
 	deleteSourceByUriDigestMutex       sync.RWMutex
 	deleteSourceByUriDigestArgsForCall []struct {
@@ -64,7 +64,7 @@ type FakeSourceRepoInterface struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeSourceRepoInterface) DeleteSourceByUriDigest(arg1 context.Context, arg2 *api.Source) error {
+func (fake *FakeSourceRepository) DeleteSourceByUriDigest(arg1 context.Context, arg2 *api.Source) error {
 	fake.deleteSourceByUriDigestMutex.Lock()
 	ret, specificReturn := fake.deleteSourceByUriDigestReturnsOnCall[len(fake.deleteSourceByUriDigestArgsForCall)]
 	fake.deleteSourceByUriDigestArgsForCall = append(fake.deleteSourceByUriDigestArgsForCall, struct {
@@ -84,26 +84,26 @@ func (fake *FakeSourceRepoInterface) DeleteSourceByUriDigest(arg1 context.Contex
 	return fakeReturns.result1
 }
 
-func (fake *FakeSourceRepoInterface) DeleteSourceByUriDigestCallCount() int {
+func (fake *FakeSourceRepository) DeleteSourceByUriDigestCallCount() int {
 	fake.deleteSourceByUriDigestMutex.RLock()
 	defer fake.deleteSourceByUriDigestMutex.RUnlock()
 	return len(fake.deleteSourceByUriDigestArgsForCall)
 }
 
-func (fake *FakeSourceRepoInterface) DeleteSourceByUriDigestCalls(stub func(context.Context, *api.Source) error) {
+func (fake *FakeSourceRepository) DeleteSourceByUriDigestCalls(stub func(context.Context, *api.Source) error) {
 	fake.deleteSourceByUriDigestMutex.Lock()
 	defer fake.deleteSourceByUriDigestMutex.Unlock()
 	fake.DeleteSourceByUriDigestStub = stub
 }
 
-func (fake *FakeSourceRepoInterface) DeleteSourceByUriDigestArgsForCall(i int) (context.Context, *api.Source) {
+func (fake *FakeSourceRepository) DeleteSourceByUriDigestArgsForCall(i int) (context.Context, *api.Source) {
 	fake.deleteSourceByUriDigestMutex.RLock()
 	defer fake.deleteSourceByUriDigestMutex.RUnlock()
 	argsForCall := fake.deleteSourceByUriDigestArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeSourceRepoInterface) DeleteSourceByUriDigestReturns(result1 error) {
+func (fake *FakeSourceRepository) DeleteSourceByUriDigestReturns(result1 error) {
 	fake.deleteSourceByUriDigestMutex.Lock()
 	defer fake.deleteSourceByUriDigestMutex.Unlock()
 	fake.DeleteSourceByUriDigestStub = nil
@@ -112,7 +112,7 @@ func (fake *FakeSourceRepoInterface) DeleteSourceByUriDigestReturns(result1 erro
 	}{result1}
 }
 
-func (fake *FakeSourceRepoInterface) DeleteSourceByUriDigestReturnsOnCall(i int, result1 error) {
+func (fake *FakeSourceRepository) DeleteSourceByUriDigestReturnsOnCall(i int, result1 error) {
 	fake.deleteSourceByUriDigestMutex.Lock()
 	defer fake.deleteSourceByUriDigestMutex.Unlock()
 	fake.DeleteSourceByUriDigestStub = nil
@@ -126,7 +126,7 @@ func (fake *FakeSourceRepoInterface) DeleteSourceByUriDigestReturnsOnCall(i int,
 	}{result1}
 }
 
-func (fake *FakeSourceRepoInterface) GetSourceByUriDigest(arg1 context.Context, arg2 string) (*api.Source, error) {
+func (fake *FakeSourceRepository) GetSourceByUriDigest(arg1 context.Context, arg2 string) (*api.Source, error) {
 	fake.getSourceByUriDigestMutex.Lock()
 	ret, specificReturn := fake.getSourceByUriDigestReturnsOnCall[len(fake.getSourceByUriDigestArgsForCall)]
 	fake.getSourceByUriDigestArgsForCall = append(fake.getSourceByUriDigestArgsForCall, struct {
@@ -146,26 +146,26 @@ func (fake *FakeSourceRepoInterface) GetSourceByUriDigest(arg1 context.Context, 
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeSourceRepoInterface) GetSourceByUriDigestCallCount() int {
+func (fake *FakeSourceRepository) GetSourceByUriDigestCallCount() int {
 	fake.getSourceByUriDigestMutex.RLock()
 	defer fake.getSourceByUriDigestMutex.RUnlock()
 	return len(fake.getSourceByUriDigestArgsForCall)
 }
 
-func (fake *FakeSourceRepoInterface) GetSourceByUriDigestCalls(stub func(context.Context, string) (*api.Source, error)) {
+func (fake *FakeSourceRepository) GetSourceByUriDigestCalls(stub func(context.Context, string) (*api.Source, error)) {
 	fake.getSourceByUriDigestMutex.Lock()
 	defer fake.getSourceByUriDigestMutex.Unlock()
 	fake.GetSourceByUriDigestStub = stub
 }
 
-func (fake *FakeSourceRepoInterface) GetSourceByUriDigestArgsForCall(i int) (context.Context, string) {
+func (fake *FakeSourceRepository) GetSourceByUriDigestArgsForCall(i int) (context.Context, string) {
 	fake.getSourceByUriDigestMutex.RLock()
 	defer fake.getSourceByUriDigestMutex.RUnlock()
 	argsForCall := fake.getSourceByUriDigestArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeSourceRepoInterface) GetSourceByUriDigestReturns(result1 *api.Source, result2 error) {
+func (fake *FakeSourceRepository) GetSourceByUriDigestReturns(result1 *api.Source, result2 error) {
 	fake.getSourceByUriDigestMutex.Lock()
 	defer fake.getSourceByUriDigestMutex.Unlock()
 	fake.GetSourceByUriDigestStub = nil
@@ -175,7 +175,7 @@ func (fake *FakeSourceRepoInterface) GetSourceByUriDigestReturns(result1 *api.So
 	}{result1, result2}
 }
 
-func (fake *FakeSourceRepoInterface) GetSourceByUriDigestReturnsOnCall(i int, result1 *api.Source, result2 error) {
+func (fake *FakeSourceRepository) GetSourceByUriDigestReturnsOnCall(i int, result1 *api.Source, result2 error) {
 	fake.getSourceByUriDigestMutex.Lock()
 	defer fake.getSourceByUriDigestMutex.Unlock()
 	fake.GetSourceByUriDigestStub = nil
@@ -191,7 +191,7 @@ func (fake *FakeSourceRepoInterface) GetSourceByUriDigestReturnsOnCall(i int, re
 	}{result1, result2}
 }
 
-func (fake *FakeSourceRepoInterface) PostSource(arg1 context.Context, arg2 *api.SourceInput) error {
+func (fake *FakeSourceRepository) PostSource(arg1 context.Context, arg2 *api.SourceInput) error {
 	fake.postSourceMutex.Lock()
 	ret, specificReturn := fake.postSourceReturnsOnCall[len(fake.postSourceArgsForCall)]
 	fake.postSourceArgsForCall = append(fake.postSourceArgsForCall, struct {
@@ -211,26 +211,26 @@ func (fake *FakeSourceRepoInterface) PostSource(arg1 context.Context, arg2 *api.
 	return fakeReturns.result1
 }
 
-func (fake *FakeSourceRepoInterface) PostSourceCallCount() int {
+func (fake *FakeSourceRepository) PostSourceCallCount() int {
 	fake.postSourceMutex.RLock()
 	defer fake.postSourceMutex.RUnlock()
 	return len(fake.postSourceArgsForCall)
 }
 
-func (fake *FakeSourceRepoInterface) PostSourceCalls(stub func(context.Context, *api.SourceInput) error) {
+func (fake *FakeSourceRepository) PostSourceCalls(stub func(context.Context, *api.SourceInput) error) {
 	fake.postSourceMutex.Lock()
 	defer fake.postSourceMutex.Unlock()
 	fake.PostSourceStub = stub
 }
 
-func (fake *FakeSourceRepoInterface) PostSourceArgsForCall(i int) (context.Context, *api.SourceInput) {
+func (fake *FakeSourceRepository) PostSourceArgsForCall(i int) (context.Context, *api.SourceInput) {
 	fake.postSourceMutex.RLock()
 	defer fake.postSourceMutex.RUnlock()
 	argsForCall := fake.postSourceArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeSourceRepoInterface) PostSourceReturns(result1 error) {
+func (fake *FakeSourceRepository) PostSourceReturns(result1 error) {
 	fake.postSourceMutex.Lock()
 	defer fake.postSourceMutex.Unlock()
 	fake.PostSourceStub = nil
@@ -239,7 +239,7 @@ func (fake *FakeSourceRepoInterface) PostSourceReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeSourceRepoInterface) PostSourceReturnsOnCall(i int, result1 error) {
+func (fake *FakeSourceRepository) PostSourceReturnsOnCall(i int, result1 error) {
 	fake.postSourceMutex.Lock()
 	defer fake.postSourceMutex.Unlock()
 	fake.PostSourceStub = nil
@@ -253,7 +253,7 @@ func (fake *FakeSourceRepoInterface) PostSourceReturnsOnCall(i int, result1 erro
 	}{result1}
 }
 
-func (fake *FakeSourceRepoInterface) UpdateSourceByUriDigest(arg1 context.Context, arg2 *api.SourceInput, arg3 string) error {
+func (fake *FakeSourceRepository) UpdateSourceByUriDigest(arg1 context.Context, arg2 *api.SourceInput, arg3 string) error {
 	fake.updateSourceByUriDigestMutex.Lock()
 	ret, specificReturn := fake.updateSourceByUriDigestReturnsOnCall[len(fake.updateSourceByUriDigestArgsForCall)]
 	fake.updateSourceByUriDigestArgsForCall = append(fake.updateSourceByUriDigestArgsForCall, struct {
@@ -274,26 +274,26 @@ func (fake *FakeSourceRepoInterface) UpdateSourceByUriDigest(arg1 context.Contex
 	return fakeReturns.result1
 }
 
-func (fake *FakeSourceRepoInterface) UpdateSourceByUriDigestCallCount() int {
+func (fake *FakeSourceRepository) UpdateSourceByUriDigestCallCount() int {
 	fake.updateSourceByUriDigestMutex.RLock()
 	defer fake.updateSourceByUriDigestMutex.RUnlock()
 	return len(fake.updateSourceByUriDigestArgsForCall)
 }
 
-func (fake *FakeSourceRepoInterface) UpdateSourceByUriDigestCalls(stub func(context.Context, *api.SourceInput, string) error) {
+func (fake *FakeSourceRepository) UpdateSourceByUriDigestCalls(stub func(context.Context, *api.SourceInput, string) error) {
 	fake.updateSourceByUriDigestMutex.Lock()
 	defer fake.updateSourceByUriDigestMutex.Unlock()
 	fake.UpdateSourceByUriDigestStub = stub
 }
 
-func (fake *FakeSourceRepoInterface) UpdateSourceByUriDigestArgsForCall(i int) (context.Context, *api.SourceInput, string) {
+func (fake *FakeSourceRepository) UpdateSourceByUriDigestArgsForCall(i int) (context.Context, *api.SourceInput, string) {
 	fake.updateSourceByUriDigestMutex.RLock()
 	defer fake.updateSourceByUriDigestMutex.RUnlock()
 	argsForCall := fake.updateSourceByUriDigestArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeSourceRepoInterface) UpdateSourceByUriDigestReturns(result1 error) {
+func (fake *FakeSourceRepository) UpdateSourceByUriDigestReturns(result1 error) {
 	fake.updateSourceByUriDigestMutex.Lock()
 	defer fake.updateSourceByUriDigestMutex.Unlock()
 	fake.UpdateSourceByUriDigestStub = nil
@@ -302,7 +302,7 @@ func (fake *FakeSourceRepoInterface) UpdateSourceByUriDigestReturns(result1 erro
 	}{result1}
 }
 
-func (fake *FakeSourceRepoInterface) UpdateSourceByUriDigestReturnsOnCall(i int, result1 error) {
+func (fake *FakeSourceRepository) UpdateSourceByUriDigestReturnsOnCall(i int, result1 error) {
 	fake.updateSourceByUriDigestMutex.Lock()
 	defer fake.updateSourceByUriDigestMutex.Unlock()
 	fake.UpdateSourceByUriDigestStub = nil
@@ -316,7 +316,7 @@ func (fake *FakeSourceRepoInterface) UpdateSourceByUriDigestReturnsOnCall(i int,
 	}{result1}
 }
 
-func (fake *FakeSourceRepoInterface) Invocations() map[string][][]interface{} {
+func (fake *FakeSourceRepository) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
@@ -326,7 +326,7 @@ func (fake *FakeSourceRepoInterface) Invocations() map[string][][]interface{} {
 	return copiedInvocations
 }
 
-func (fake *FakeSourceRepoInterface) recordInvocation(key string, args []interface{}) {
+func (fake *FakeSourceRepository) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
@@ -338,4 +338,4 @@ func (fake *FakeSourceRepoInterface) recordInvocation(key string, args []interfa
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ source.SourceRepoInterface = new(FakeSourceRepoInterface)
+var _ source.SourceRepository = new(FakeSourceRepository)

--- a/pkg/handlers/source.go
+++ b/pkg/handlers/source.go
@@ -1,14 +1,15 @@
 package handlers
 
 import (
+	"context"
 	"source-score/pkg/domain/source"
 )
 
 type SourceHandler struct {
-	sourceSvc *source.SourceService
+	sourceSvc source.SourceService
 }
 
-func NewSourceHandler(sourceSvc *source.SourceService) *SourceHandler {
+func NewSourceHandler(ctx context.Context, sourceSvc source.SourceService) *SourceHandler {
 	return &SourceHandler{
 		sourceSvc: sourceSvc,
 	}

--- a/pkg/http/router.go
+++ b/pkg/http/router.go
@@ -1,9 +1,11 @@
 package http
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"source-score/pkg/api"
+	"source-score/pkg/domain/source"
 	"source-score/pkg/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,11 +13,13 @@ import (
 
 type router struct {
 	pingHandler *handlers.PingHandler
+	srcHandler  *handlers.SourceHandler
 }
 
-func NewRouter() *router {
+func NewRouter(ctx context.Context, sourceSvc source.SourceService) *router {
 	return &router{
 		pingHandler: handlers.NewPingHandler(),
+		srcHandler:  handlers.NewSourceHandler(ctx, sourceSvc),
 	}
 }
 


### PR DESCRIPTION
## Description

Connects server to the source model layers

## Related Issue

Closes: #17 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (e.g., updating dependencies, fixing typos)

## Checklist

- [x] I have read the contributing guidelines.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connected the server to the source domain using a DB-backed `SourceService`, moved routing to `pkg/http`, and switched config to `PG_HOST`. Closes #17.

- **Refactors**
  - Moved router from `pkg/api` to `pkg/http`; `http.NewRouter(ctx, srcSvc)` now accepts a `SourceService`.
  - Added `handlers.SourceHandler` and DI in `cmd/app/main.go` (build DSN, init `cnpg` client, `SourceRepository`, `SourceService`).
  - Introduced `conf.AppUserName` and `conf.DbName`; assemble DSN with `PgHost`.
  - Renamed repo interface to `SourceRepository`; updated fakes and tests.
  - `cnpg.NewClient` now takes a DSN and simplifies error logging.

- **Migration**
  - Replace `PG_SERVER` with `PG_HOST` in env and `pkg/conf/conf.yaml`; Makefile now exports `PG_HOST` from `SERVER_HOST`.

<sup>Written for commit 5ed8911c620460f77ca1c7c423a3101510644949. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

