### PR TITLE
feat: claim ops validations

### DIFF
--- a/acceptance/claim_test.go
+++ b/acceptance/claim_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"source-score/pkg/api"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -172,6 +173,81 @@ var _ = Describe("Claim model tests", func() {
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			})
+		})
+	})
+
+	Context("Validation tests", func() {
+		When("POST request with empty sourceUriDigest is sent", func() {
+			It("should return 400 with validation error", func() {
+				claim := api.ClaimInput{
+					SourceUriDigest: "",
+					Summary:         "summary",
+					Title:           "title",
+					Uri:             "https://ok",
+				}
+				body, err := json.Marshal(claim)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("sourceuridigest"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("required"))
+			})
+		})
+
+		When("POST request with empty title and summary is sent", func() {
+			It("should return 400 with validation error mentioning Title and Summary", func() {
+				claim := api.ClaimInput{
+					SourceUriDigest: "somedigest",
+					Summary:         "",
+					Title:           "",
+					Uri:             "https://ok",
+				}
+				body, err := json.Marshal(claim)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("title"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("summary"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("required"))
+			})
+		})
+
+		When("POST request with non-https Uri is sent", func() {
+			It("should return 400 with validation error mentioning Uri and httpsurl", func() {
+				claim := api.ClaimInput{
+					SourceUriDigest: "somedigest",
+					Summary:         "summary",
+					Title:           "title",
+					Uri:             "http://not-https",
+				}
+				body, err := json.Marshal(claim)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("uri"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("httpsurl"))
 			})
 		})
 	})

--- a/acceptance/claim_test.go
+++ b/acceptance/claim_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Claim model tests", func() {
 
 				claim1 := api.ClaimInput{
 					SourceUriDigest: srcResp.UriDigest,
-					Summary:         &sampleClaim1.Summary,
+					Summary:         sampleClaim1.Summary,
 					Title:           sampleClaim1.Title,
 					Uri:             sampleClaim1.Uri,
 				}
@@ -60,7 +60,7 @@ var _ = Describe("Claim model tests", func() {
 
 				claim2 := api.ClaimInput{
 					SourceUriDigest: srcResp.UriDigest,
-					Summary:         &sampleClaim2.Summary,
+					Summary:         sampleClaim2.Summary,
 					Title:           sampleClaim2.Title,
 					Uri:             sampleClaim2.Uri,
 				}

--- a/acceptance/claim_test.go
+++ b/acceptance/claim_test.go
@@ -12,6 +12,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func ptrString(s string) *string { return &s }
+
 var _ = Describe("Claim model tests", func() {
 	// claim endpoints
 	endpoint, err := url.JoinPath(baseUrl, "/api/v1/claim")
@@ -153,6 +155,74 @@ var _ = Describe("Claim model tests", func() {
 				Expect(c.Title).To(Equal(updatedTitle))
 				Expect(c.Summary).To(Equal(updatedSummary))
 			})
+
+			It("should update only the summary when only summary is provided", func() {
+				claimUrl, err := url.JoinPath(endpoint, claim1Digest)
+				Expect(err).To(BeNil())
+
+				updatedSummary2 := "Patched Claim Summary Only"
+				patchBody := api.ClaimPatchInput{
+					Summary: &updatedSummary2,
+				}
+				body, err := json.Marshal(patchBody)
+				Expect(err).To(BeNil())
+
+				req, err := http.NewRequest(http.MethodPatch, claimUrl, bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				req.Header.Set("Content-Type", "application/json")
+
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+
+				// verify update
+				resp, err = http.Get(claimUrl)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				var c api.Claim
+				err = json.NewDecoder(resp.Body).Decode(&c)
+				Expect(err).To(BeNil())
+				// title should remain as previously patched
+				Expect(c.Title).To(Equal("Patched Claim Title"))
+				Expect(c.Summary).To(Equal(updatedSummary2))
+			})
+
+			It("should update only the title when only title is provided", func() {
+				claimUrl, err := url.JoinPath(endpoint, claim1Digest)
+				Expect(err).To(BeNil())
+
+				updatedTitle2 := "Patched Claim Title Only"
+				patchBody := api.ClaimPatchInput{
+					Title: &updatedTitle2,
+				}
+				body, err := json.Marshal(patchBody)
+				Expect(err).To(BeNil())
+
+				req, err := http.NewRequest(http.MethodPatch, claimUrl, bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				req.Header.Set("Content-Type", "application/json")
+
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+
+				// verify update
+				resp, err = http.Get(claimUrl)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				var c api.Claim
+				err = json.NewDecoder(resp.Body).Decode(&c)
+				Expect(err).To(BeNil())
+				// summary should remain as previously patched in prior test
+				Expect(c.Summary).To(Equal("Patched Claim Summary Only"))
+				Expect(c.Title).To(Equal(updatedTitle2))
+			})
 		})
 
 		When("DELETE request is sent to delete the created claim", func() {
@@ -251,6 +321,23 @@ var _ = Describe("Claim model tests", func() {
 			})
 		})
 
+		When("GET request is sent for a non-existent claim", func() {
+			It("should return 404 with claim not found error", func() {
+				claimUrl, err := url.JoinPath(endpoint, "doesnotexist")
+				Expect(err).To(BeNil())
+
+				resp, err := http.Get(claimUrl)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("claim not found"))
+			})
+		})
+
 		When("DELETE request is sent for a non-existent claim", func() {
 			It("should return 404 with claim not found error", func() {
 				claimUrl, err := url.JoinPath(endpoint, "doesnotexistdigest")
@@ -268,6 +355,64 @@ var _ = Describe("Claim model tests", func() {
 				err = json.NewDecoder(resp.Body).Decode(&errResp)
 				Expect(err).To(BeNil())
 				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("claim not found"))
+			})
+		})
+
+		When("PATCH request is sent for a non-existent claim", func() {
+			It("should return 404 with claim not found error", func() {
+				claimUrl, err := url.JoinPath(endpoint, "doesnotexist")
+				Expect(err).To(BeNil())
+
+				patchBody := api.ClaimPatchInput{
+					Title:   ptrString("irrelevant"),
+					Summary: ptrString("irrelevant summary"),
+				}
+				body, err := json.Marshal(patchBody)
+				Expect(err).To(BeNil())
+
+				req, err := http.NewRequest(http.MethodPatch, claimUrl, bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				req.Header.Set("Content-Type", "application/json")
+
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("claim not found"))
+			})
+		})
+
+		When("PATCH request with empty title and summary is sent", func() {
+			It("should return 400 with validation error mentioning Title and Summary", func() {
+				claimUrl, err := url.JoinPath(endpoint, claim1Digest)
+				Expect(err).To(BeNil())
+
+				patchBody := api.ClaimPatchInput{
+					Title:   ptrString(""),
+					Summary: ptrString(""),
+				}
+				body, err := json.Marshal(patchBody)
+				Expect(err).To(BeNil())
+
+				req, err := http.NewRequest(http.MethodPatch, claimUrl, bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				req.Header.Set("Content-Type", "application/json")
+
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("title"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("summary"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("nonempty"))
 			})
 		})
 	})

--- a/acceptance/claim_test.go
+++ b/acceptance/claim_test.go
@@ -250,5 +250,25 @@ var _ = Describe("Claim model tests", func() {
 				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("httpsurl"))
 			})
 		})
+
+		When("DELETE request is sent for a non-existent claim", func() {
+			It("should return 404 with claim not found error", func() {
+				claimUrl, err := url.JoinPath(endpoint, "doesnotexistdigest")
+				Expect(err).To(BeNil())
+
+				req, err := http.NewRequest(http.MethodDelete, claimUrl, nil)
+				Expect(err).To(BeNil())
+
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("claim not found"))
+			})
+		})
 	})
 })

--- a/api/source-score.yaml
+++ b/api/source-score.yaml
@@ -304,6 +304,7 @@ components:
       type: object
       required:
       - sourceUriDigest
+      - summary
       - title
       - uri
       properties:
@@ -311,17 +312,22 @@ components:
           type: string
           x-oapi-codegen-extra-tags:
             binding: required
+            validate: nonempty
         summary:
           type: string
           x-oapi-codegen-extra-tags:
+            binding: required
+            validate: nonempty
         title:
           type: string
           x-oapi-codegen-extra-tags:
             binding: required
+            validate: nonempty
         uri:
           type: string
           x-oapi-codegen-extra-tags:
             binding: required
+            validate: httpsurl
 
     Claim:
       type: object

--- a/pkg/api/server.gen.go
+++ b/pkg/api/server.gen.go
@@ -24,10 +24,10 @@ type Claim struct {
 
 // ClaimInput defines model for ClaimInput.
 type ClaimInput struct {
-	SourceUriDigest string  `binding:"required" json:"sourceUriDigest"`
-	Summary         *string `json:"summary,omitempty"`
-	Title           string  `binding:"required" json:"title"`
-	Uri             string  `binding:"required" json:"uri"`
+	SourceUriDigest string `binding:"required" json:"sourceUriDigest" validate:"nonempty"`
+	Summary         string `binding:"required" json:"summary" validate:"nonempty"`
+	Title           string `binding:"required" json:"title" validate:"nonempty"`
+	Uri             string `binding:"required" json:"uri" validate:"httpsurl"`
 }
 
 // ClaimPatchInput defines model for ClaimPatchInput.

--- a/pkg/domain/claim/claim_repository.go
+++ b/pkg/domain/claim/claim_repository.go
@@ -50,14 +50,9 @@ func (cr *claimRepository) PostClaim(ctx context.Context, claimInput *api.ClaimI
 	}
 	uriDigest := hex.EncodeToString(hash.Sum(nil))
 
-	summary := ""
-	if claimInput.Summary != nil {
-		summary = *claimInput.Summary
-	}
-
 	claim := &api.Claim{
 		SourceUriDigest: claimInput.SourceUriDigest,
-		Summary:         summary,
+		Summary:         claimInput.Summary,
 		Title:           claimInput.Title,
 		Uri:             claimInput.Uri,
 		UriDigest:       uriDigest,

--- a/pkg/domain/claim/claim_repository_test.go
+++ b/pkg/domain/claim/claim_repository_test.go
@@ -98,4 +98,25 @@ var _ = Describe("Claim repository layer unit tests", func() {
 			})
 		})
 	})
+
+	Context("Validation tests", func() {
+		When("Retrieving a non-existent claim by uri digest", func() {
+			It("Should return gorm.ErrRecordNotFound", func() {
+				_, err := claimRepo.GetClaimByUriDigest(context.TODO(), "doesnotexist")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, gorm.ErrRecordNotFound)).To(BeTrue())
+			})
+		})
+
+		When("Patching a non-existent claim by uri digest", func() {
+			It("Should return gorm.ErrRecordNotFound", func() {
+				newTitle := "New Title"
+				patchInput := &api.ClaimPatchInput{Title: &newTitle}
+
+				err := claimRepo.PatchClaimByUriDigest(context.TODO(), patchInput, "doesnotexist")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, gorm.ErrRecordNotFound)).To(BeTrue())
+			})
+		})
+	})
 })

--- a/pkg/domain/claim/claim_repository_test.go
+++ b/pkg/domain/claim/claim_repository_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Claim repository layer unit tests", func() {
 			It("Should create the claims and return their uri digests", func() {
 				input := api.ClaimInput{
 					SourceUriDigest: sampleClaim1.SourceUriDigest,
-					Summary:         &sampleClaim1.Summary,
+					Summary:         sampleClaim1.Summary,
 					Title:           sampleClaim1.Title,
 					Uri:             sampleClaim1.Uri,
 				}
@@ -29,7 +29,7 @@ var _ = Describe("Claim repository layer unit tests", func() {
 
 				input = api.ClaimInput{
 					SourceUriDigest: sampleClaim2.SourceUriDigest,
-					Summary:         &sampleClaim2.Summary,
+					Summary:         sampleClaim2.Summary,
 					Title:           sampleClaim2.Title,
 					Uri:             sampleClaim2.Uri,
 				}

--- a/pkg/domain/claim/claim_service.go
+++ b/pkg/domain/claim/claim_service.go
@@ -35,6 +35,9 @@ func init() {
 	if err := claimValidate.RegisterValidation("nonempty", helpers.ValidateNonEmpty); err != nil {
 		panic(fmt.Sprintf("failed to register nonempty validator with error: %v", err))
 	}
+	if err := claimValidate.RegisterValidation("httpsurl", helpers.ValidateHttpsURL); err != nil {
+		panic(fmt.Sprintf("failed to register httpsurl validator with error: %v", err))
+	}
 }
 
 func NewClaimService(ctx context.Context, claimRepo ClaimRepository) ClaimService {
@@ -90,5 +93,20 @@ func (svc *claimService) PatchClaimByUriDigest(ctx context.Context, claimInput *
 }
 
 func (svc *claimService) PostClaim(ctx context.Context, claimInput *api.ClaimInput) (string, error) {
+	err := claimValidate.Struct(claimInput)
+	if err != nil {
+		if _, ok := err.(*validator.InvalidValidationError); ok {
+			return "", fmt.Errorf("%w: %s", apperrors.ErrValidationLogic, err.Error())
+		}
+		combinedErrs := ""
+		for _, e := range err.(validator.ValidationErrors) {
+			combinedErrs = fmt.Sprintf(
+				"%s\n%s validation failed for value %v with error %s", combinedErrs, e.Field(), e.Value(), e.Tag(),
+			)
+		}
+		combinedErrs = strings.TrimSpace(combinedErrs)
+		return "", fmt.Errorf("%w: %s", apperrors.ErrInvalidClaim, combinedErrs)
+	}
+
 	return svc.claimRepo.PostClaim(ctx, claimInput)
 }

--- a/pkg/domain/claim/claim_service_test.go
+++ b/pkg/domain/claim/claim_service_test.go
@@ -10,6 +10,8 @@ import (
 	"source-score/pkg/domain/claim"
 	"source-score/pkg/domain/claim/claimfakes"
 
+	"gorm.io/gorm"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -174,6 +176,18 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 				Expect(strings.Contains(strings.ToLower(err.Error()), "uri")).To(BeTrue())
 				Expect(strings.Contains(strings.ToLower(err.Error()), "httpsurl")).To(BeTrue())
 				Expect(fakeClaimRepo.PostClaimCallCount()).To(Equal(postClaimCalls))
+			})
+		})
+
+		When("Deleting a non-existent claim by uri digest", func() {
+			It("Should return ErrClaimNotFound and not call Delete on repo", func() {
+				fakeClaimRepo.GetClaimByUriDigestReturns(nil, gorm.ErrRecordNotFound)
+				before := fakeClaimRepo.DeleteClaimByUriDigestCallCount()
+
+				err := claimSvc.DeleteClaimByUriDigest(context.TODO(), "doesnotexist")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, apperrors.ErrClaimNotFound)).To(BeTrue())
+				Expect(fakeClaimRepo.DeleteClaimByUriDigestCallCount()).To(Equal(before))
 			})
 		})
 	})

--- a/pkg/domain/claim/claim_service_test.go
+++ b/pkg/domain/claim/claim_service_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 
 				input := api.ClaimInput{
 					SourceUriDigest: sampleClaim1.SourceUriDigest,
-					Summary:         &sampleClaim1.Summary,
+					Summary:         sampleClaim1.Summary,
 					Title:           sampleClaim1.Title,
 					Uri:             sampleClaim1.Uri,
 				}
@@ -37,7 +37,7 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 
 				input = api.ClaimInput{
 					SourceUriDigest: sampleClaim2.SourceUriDigest,
-					Summary:         &sampleClaim2.Summary,
+					Summary:         sampleClaim2.Summary,
 					Title:           sampleClaim2.Title,
 					Uri:             sampleClaim2.Uri,
 				}

--- a/pkg/domain/claim/claim_service_test.go
+++ b/pkg/domain/claim/claim_service_test.go
@@ -2,7 +2,11 @@ package claim_test
 
 import (
 	"context"
+	"errors"
+	"strings"
+
 	"source-score/pkg/api"
+	"source-score/pkg/apperrors"
 	"source-score/pkg/domain/claim"
 	"source-score/pkg/domain/claim/claimfakes"
 
@@ -110,6 +114,66 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 				Expect(argDigest).To(Equal(claim1Digest))
 				Expect(*argInput.Title).To(Equal(newTitle))
 				Expect(*argInput.Summary).To(Equal(newSummary))
+			})
+		})
+	})
+
+	Context("Validation tests", func() {
+		When("Posting a claim with empty source uri digest", func() {
+			It("Should return ErrInvalidClaim", func() {
+				input := api.ClaimInput{
+					SourceUriDigest: "",
+					Summary:         "non-empty",
+					Title:           "title",
+					Uri:             "https://ok",
+				}
+
+				postClaimCalls := fakeClaimRepo.PostClaimCallCount()
+				_, err := claimSvc.PostClaim(context.TODO(), &input)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, apperrors.ErrInvalidClaim)).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "sourceuridigest")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "nonempty")).To(BeTrue())
+				Expect(fakeClaimRepo.PostClaimCallCount()).To(Equal(postClaimCalls))
+			})
+		})
+
+		When("Posting a claim with empty title and summary", func() {
+			It("Should return ErrInvalidClaim and mention Title and Summary", func() {
+				input := api.ClaimInput{
+					SourceUriDigest: "srcdigest",
+					Summary:         "",
+					Title:           "",
+					Uri:             "https://ok",
+				}
+
+				postClaimCalls := fakeClaimRepo.PostClaimCallCount()
+				_, err := claimSvc.PostClaim(context.TODO(), &input)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, apperrors.ErrInvalidClaim)).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "title")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "summary")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "nonempty")).To(BeTrue())
+				Expect(fakeClaimRepo.PostClaimCallCount()).To(Equal(postClaimCalls))
+			})
+		})
+
+		When("Posting a claim with a non-https Uri", func() {
+			It("Should return ErrInvalidClaim and mention Uri httpsurl", func() {
+				input := api.ClaimInput{
+					SourceUriDigest: "srcdigest",
+					Summary:         "summary",
+					Title:           "title",
+					Uri:             "http://not-https",
+				}
+
+				postClaimCalls := fakeClaimRepo.PostClaimCallCount()
+				_, err := claimSvc.PostClaim(context.TODO(), &input)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, apperrors.ErrInvalidClaim)).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "uri")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "httpsurl")).To(BeTrue())
+				Expect(fakeClaimRepo.PostClaimCallCount()).To(Equal(postClaimCalls))
 			})
 		})
 	})

--- a/pkg/domain/claim/claim_service_test.go
+++ b/pkg/domain/claim/claim_service_test.go
@@ -117,6 +117,43 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 				Expect(*argInput.Title).To(Equal(newTitle))
 				Expect(*argInput.Summary).To(Equal(newSummary))
 			})
+
+			It("Should patch only the summary when title is nil", func() {
+				newSummary := "Summary only update"
+				patchInput := api.ClaimPatchInput{
+					Summary: &newSummary,
+					Title:   nil,
+				}
+
+				before := fakeClaimRepo.PatchClaimByUriDigestCallCount()
+				fakeClaimRepo.PatchClaimByUriDigestReturns(nil)
+				err := claimSvc.PatchClaimByUriDigest(context.TODO(), &patchInput, claim1Digest)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fakeClaimRepo.PatchClaimByUriDigestCallCount()).To(Equal(before + 1))
+				_, argInput, argDigest := fakeClaimRepo.PatchClaimByUriDigestArgsForCall(before)
+				Expect(argDigest).To(Equal(claim1Digest))
+				Expect(argInput.Title).To(BeNil())
+				Expect(*argInput.Summary).To(Equal(newSummary))
+			})
+
+			It("Should patch only the title when summary is nil", func() {
+				newTitle := "Title only update"
+				patchInput := api.ClaimPatchInput{
+					Summary: nil,
+					Title:   &newTitle,
+				}
+
+				before := fakeClaimRepo.PatchClaimByUriDigestCallCount()
+				fakeClaimRepo.PatchClaimByUriDigestReturns(nil)
+				err := claimSvc.PatchClaimByUriDigest(context.TODO(), &patchInput, claim1Digest)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fakeClaimRepo.PatchClaimByUriDigestCallCount()).To(Equal(before + 1))
+				_, argInput, argDigest := fakeClaimRepo.PatchClaimByUriDigestArgsForCall(before)
+				Expect(argDigest).To(Equal(claim1Digest))
+				Expect(*argInput.Title).To(Equal(newTitle))
+				Expect(argInput.Summary).To(BeNil())
+			})
+
 		})
 	})
 
@@ -190,5 +227,44 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 				Expect(fakeClaimRepo.DeleteClaimByUriDigestCallCount()).To(Equal(before))
 			})
 		})
+
+		When("Getting a non-existent claim by uri digest", func() {
+			It("Should return ErrClaimNotFound and nil claim", func() {
+				fakeClaimRepo.GetClaimByUriDigestReturns(nil, gorm.ErrRecordNotFound)
+
+				c, err := claimSvc.GetClaimByUriDigest(context.TODO(), "doesnotexist")
+				Expect(err).To(HaveOccurred())
+				Expect(c).To(BeNil())
+				Expect(errors.Is(err, apperrors.ErrClaimNotFound)).To(BeTrue())
+			})
+		})
+
+		When("Patching a non-existent claim by uri digest", func() {
+			It("Should return ErrClaimNotFound", func() {
+				fakeClaimRepo.PatchClaimByUriDigestReturns(gorm.ErrRecordNotFound)
+
+				patchInput := api.ClaimPatchInput{Title: nil, Summary: nil}
+				err := claimSvc.PatchClaimByUriDigest(context.TODO(), &patchInput, "doesnotexist")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, apperrors.ErrClaimNotFound)).To(BeTrue())
+			})
+		})
+
+		When("Patching a claim with empty title and summary", func() {
+			It("Should return ErrInvalidClaim and not call repo", func() {
+				empty := ""
+				patchInput := api.ClaimPatchInput{Title: &empty, Summary: &empty}
+				before := fakeClaimRepo.PatchClaimByUriDigestCallCount()
+
+				err := claimSvc.PatchClaimByUriDigest(context.TODO(), &patchInput, claim1Digest)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, apperrors.ErrInvalidClaim)).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower((err.Error())), "title")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "summary")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "nonempty")).To(BeTrue())
+				Expect(fakeClaimRepo.PatchClaimByUriDigestCallCount()).To(Equal(before))
+			})
+		})
+
 	})
 })

--- a/pkg/handlers/claim.go
+++ b/pkg/handlers/claim.go
@@ -48,6 +48,11 @@ func (ch *ClaimHandler) PostClaim(ctx *gin.Context) {
 	digest, err := ch.claimSvc.PostClaim(ctx, claimInput)
 	if err != nil {
 		switch {
+		case errors.Is(err, apperrors.ErrInvalidClaim):
+			ctx.JSON(
+				http.StatusBadRequest,
+				gin.H{"error": err.Error()},
+			)
 		default:
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		}


### PR DESCRIPTION
Fixes: #57 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict server-side validation for claim create/update to meet #57. Requires non-empty fields, enforces https URIs, supports partial PATCH, and returns clear 400/404 errors.

- **New Features**
  - Validates `ClaimInput` with `nonempty` and `httpsurl` in `pkg/domain/claim/claim_service.go`; returns `ErrInvalidClaim` with field details; `pkg/handlers/claim.go` maps this to 400.
  - `summary` is now required (string) across API/repo; updated `api/source-score.yaml` and regenerated `pkg/api/server.gen.go`.
  - PATCH supports updating only `title` or `summary`; rejects empty values with 400. GET/PATCH/DELETE check existence and return `ErrClaimNotFound` → 404.

- **Migration**
  - Send non-empty `sourceUriDigest`, `title`, and `summary`; `uri` must be `https`.
  - Handle 400 on invalid create/PATCH and 404 on GET/PATCH/DELETE for missing claims.
  - Regenerate client code if using the OpenAPI spec.

<sup>Written for commit c91f65d3a0ed380dae01c56f1945c3b159df5f1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

