### PR TITLE
feat: adds validations for proof model

### DIFF
--- a/acceptance/proof_test.go
+++ b/acceptance/proof_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"source-score/pkg/api"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -187,6 +188,204 @@ var _ = Describe("Proof model tests", func() {
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			})
+		})
+	})
+
+	Context("Validation tests", func() {
+		When("POST request with space in ClaimUriDigest is sent", func() {
+			It("should return 400 with validation error mentioning nospace", func() {
+				supports := true
+				proof := api.ProofInput{
+					ClaimUriDigest: "claim digest",
+					ReviewedBy:     "ValidReviewer",
+					SupportsClaim:  &supports,
+					Uri:            "https://example.com",
+				}
+				body, err := json.Marshal(proof)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("claimuridigest"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("nospace"))
+			})
+		})
+
+		When("POST request with space in ReviewedBy is sent", func() {
+			It("should return 400 with validation error mentioning nospace", func() {
+				supports := true
+				proof := api.ProofInput{
+					ClaimUriDigest: "validclaimdigest",
+					ReviewedBy:     "Reviewer Name",
+					SupportsClaim:  &supports,
+					Uri:            "https://example.com",
+				}
+				body, err := json.Marshal(proof)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("reviewedby"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("nospace"))
+			})
+		})
+
+		When("POST request with empty ReviewedBy and ClaimUriDigest is sent", func() {
+			It("should return 400 with validation error mentioning nonempty", func() {
+				supports := true
+				proof := api.ProofInput{
+					ClaimUriDigest: "",
+					ReviewedBy:     "",
+					SupportsClaim:  &supports,
+					Uri:            "https://example.com",
+				}
+				body, err := json.Marshal(proof)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("claimuridigest"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("reviewedby"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("required"))
+			})
+		})
+
+		When("POST request without SupportsClaim is sent", func() {
+			It("should return 400 with validation error mentioning supportsClaim", func() {
+				proof := api.ProofInput{
+					ClaimUriDigest: "validclaimdigest",
+					ReviewedBy:     "ValidReviewer",
+					Uri:            "https://example.com",
+				}
+				body, err := json.Marshal(proof)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("supportsclaim"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("required"))
+			})
+		})
+
+		When("POST request with invalid url in Uri is sent", func() {
+			It("should return 400 with validation error mentioning httpsurl", func() {
+				supports := true
+				proof := api.ProofInput{
+					ClaimUriDigest: "validclaimdigest",
+					ReviewedBy:     "ValidReviewer",
+					SupportsClaim:  &supports,
+					Uri:            "http://not-https.com",
+				}
+				body, err := json.Marshal(proof)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("uri"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("httpsurl"))
+			})
+		})
+
+		When("DELETE request is sent for a non-existent proof", func() {
+			It("should return 404 with proof not found error", func() {
+				proofUrl, err := url.JoinPath(endpoint, "doesnotexist")
+				Expect(err).To(BeNil())
+
+				req, err := http.NewRequest(http.MethodDelete, proofUrl, nil)
+				Expect(err).To(BeNil())
+
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("proof not found"))
+			})
+		})
+
+		When("PATCH request with empty ReviewedBy is sent", func() {
+			It("should return 400 with validation error mentioning nonempty", func() {
+				proofUrl, err := url.JoinPath(endpoint, proof1Digest)
+				Expect(err).To(BeNil())
+
+				patchBody := api.ProofPatchInput{ReviewedBy: ""}
+				body, err := json.Marshal(patchBody)
+				Expect(err).To(BeNil())
+
+				req, err := http.NewRequest(http.MethodPatch, proofUrl, bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				req.Header.Set("Content-Type", "application/json")
+
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("reviewedby"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("required"))
+			})
+		})
+
+		When("PATCH request with space in ReviewedBy value is sent", func() {
+			It("should return 400 with validation error mentioning nospace", func() {
+				proofUrl, err := url.JoinPath(endpoint, proof1Digest)
+				Expect(err).To(BeNil())
+
+				patchBody := api.ProofPatchInput{ReviewedBy: "Reviewer Name"}
+				body, err := json.Marshal(patchBody)
+				Expect(err).To(BeNil())
+
+				req, err := http.NewRequest(http.MethodPatch, proofUrl, bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				req.Header.Set("Content-Type", "application/json")
+
+				resp, err := client.Do(req)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("reviewedby"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("nospace"))
 			})
 		})
 	})

--- a/pkg/domain/proof/proof_repository_test.go
+++ b/pkg/domain/proof/proof_repository_test.go
@@ -2,10 +2,12 @@ package proof_test
 
 import (
 	"context"
+	"errors"
 	"source-score/pkg/api"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
 )
 
 var _ = Describe("Proof repository layer unit tests", Ordered, func() {
@@ -87,6 +89,25 @@ var _ = Describe("Proof repository layer unit tests", Ordered, func() {
 
 				_, err = proofRepo.GetProofByUriDigest(context.TODO(), proof1Digest)
 				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("Validation tests", Ordered, func() {
+		When("Retrieving a non-existent proof by uri digest", func() {
+			It("Should return gorm.ErrRecordNotFound", func() {
+				_, err := proofRepo.GetProofByUriDigest(context.TODO(), "doesnotexist")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, gorm.ErrRecordNotFound)).To(BeTrue())
+			})
+		})
+
+		When("Patching a proof by uri digest that does not exist", func() {
+			It("Should return gorm.ErrRecordNotFound", func() {
+				patchInput := &api.ProofPatchInput{ReviewedBy: "irrelevant"}
+				err := proofRepo.PatchProofByUriDigest(context.TODO(), patchInput, "doesnotexist")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, gorm.ErrRecordNotFound)).To(BeTrue())
 			})
 		})
 	})

--- a/pkg/domain/proof/proof_service_test.go
+++ b/pkg/domain/proof/proof_service_test.go
@@ -2,13 +2,17 @@ package proof_test
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"source-score/pkg/api"
+	"source-score/pkg/apperrors"
 	"source-score/pkg/domain/proof"
 	"source-score/pkg/domain/proof/prooffakes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
 )
 
 var (
@@ -79,7 +83,7 @@ var _ = Describe("Proof model service layer unit tests", Ordered, func() {
 				_, arg := fakeProofRepo.GetProofByUriDigestArgsForCall(0)
 				Expect(arg).To(Equal(proof1Digest))
 			})
-		})		
+		})
 
 		When("Patching a proof by its uri digest", func() {
 			It("Should update the proof via repository", func() {
@@ -106,6 +110,189 @@ var _ = Describe("Proof model service layer unit tests", Ordered, func() {
 				Expect(digest).To(Equal(proof1Digest))
 				_, c := fakeProofRepo.DeleteProofByUriDigestArgsForCall(0)
 				Expect(*c).To(Equal(sampleProof1))
+			})
+		})
+	})
+
+	Context("Proof POST validation tests", func() {
+		When("Posting a proof with space in ClaimUriDigest", func() {
+			It("Should return invalid proof error with nospace validation message", func() {
+				supports := true
+				invalidInput := &api.ProofInput{
+					ClaimUriDigest: "claim digest",
+					ReviewedBy:     "ValidReviewer",
+					SupportsClaim:  &supports,
+					Uri:            "https://example.com",
+				}
+
+				postCalls := fakeProofRepo.PostProofCallCount()
+				_, err := proofSvc.PostProof(context.TODO(), invalidInput)
+
+				Expect(err).ToNot(BeNil())
+				Expect(errors.Is(err, apperrors.ErrInvalidProof)).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "claimuridigest")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "nospace")).To(BeTrue())
+				Expect(fakeProofRepo.PostProofCallCount()).To(Equal(postCalls))
+			})
+		})
+
+		When("Posting a proof with space in ReviewedBy", func() {
+			It("Should return invalid proof error with nospace validation message", func() {
+				supports := true
+				invalidInput := &api.ProofInput{
+					ClaimUriDigest: "validclaimdigest",
+					ReviewedBy:     "Reviewer Name",
+					SupportsClaim:  &supports,
+					Uri:            "https://example.com",
+				}
+
+				postCalls := fakeProofRepo.PostProofCallCount()
+				_, err := proofSvc.PostProof(context.TODO(), invalidInput)
+
+				Expect(err).ToNot(BeNil())
+				Expect(errors.Is(err, apperrors.ErrInvalidProof)).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "reviewedby")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "nospace")).To(BeTrue())
+				Expect(fakeProofRepo.PostProofCallCount()).To(Equal(postCalls))
+			})
+		})
+
+		When("Posting a proof with empty ReviewedBy and ClaimUriDigest", func() {
+			It("Should return invalid proof error with nonempty validation message", func() {
+				supports := true
+				invalidInput := &api.ProofInput{
+					ClaimUriDigest: "",
+					ReviewedBy:     "",
+					SupportsClaim:  &supports,
+					Uri:            "https://example.com",
+				}
+
+				postCalls := fakeProofRepo.PostProofCallCount()
+				_, err := proofSvc.PostProof(context.TODO(), invalidInput)
+
+				Expect(err).ToNot(BeNil())
+				Expect(errors.Is(err, apperrors.ErrInvalidProof)).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "claimuridigest")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "reviewedby")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "nonempty")).To(BeTrue())
+				Expect(fakeProofRepo.PostProofCallCount()).To(Equal(postCalls))
+			})
+		})
+
+		When("Posting a proof without SupportsClaim", func() {
+			It("Should return invalid proof error with nonempty validation message", func() {
+				invalidInput := &api.ProofInput{
+					ClaimUriDigest: "validclaimdigest",
+					ReviewedBy:     "ValidReviewer",
+					Uri:            "https://example.com",
+				}
+
+				postCalls := fakeProofRepo.PostProofCallCount()
+				_, err := proofSvc.PostProof(context.TODO(), invalidInput)
+
+				Expect(err).ToNot(BeNil())
+				Expect(errors.Is(err, apperrors.ErrInvalidProof)).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "supportsclaim")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "nonempty")).To(BeTrue())
+				Expect(fakeProofRepo.PostProofCallCount()).To(Equal(postCalls))
+			})
+		})
+
+		When("Posting a proof with invalid url in Uri", func() {
+			It("Should return invalid proof error with httpsurl validation message", func() {
+				supports := true
+				invalidInput := &api.ProofInput{
+					ClaimUriDigest: "validclaimdigest",
+					ReviewedBy:     "ValidReviewer",
+					SupportsClaim:  &supports,
+					Uri:            "http://not-https.com",
+				}
+
+				postCalls := fakeProofRepo.PostProofCallCount()
+				_, err := proofSvc.PostProof(context.TODO(), invalidInput)
+
+				Expect(err).ToNot(BeNil())
+				Expect(errors.Is(err, apperrors.ErrInvalidProof)).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "uri")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "httpsurl")).To(BeTrue())
+				Expect(fakeProofRepo.PostProofCallCount()).To(Equal(postCalls))
+			})
+		})
+	})
+
+	Context("Proof PATCH validation tests", func() {
+		When("Patching a proof with empty ReviewedBy", func() {
+			It("Should return invalid proof error with nonempty validation message", func() {
+				invalidInput := &api.ProofPatchInput{ReviewedBy: ""}
+				before := fakeProofRepo.PatchProofByUriDigestCallCount()
+
+				err := proofSvc.PatchProofByUriDigest(context.TODO(), invalidInput, proof1Digest)
+
+				Expect(err).ToNot(BeNil())
+				Expect(errors.Is(err, apperrors.ErrInvalidProof)).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "reviewedby")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "nonempty")).To(BeTrue())
+				Expect(fakeProofRepo.PatchProofByUriDigestCallCount()).To(Equal(before))
+			})
+		})
+
+		When("Patching a proof with space in ReviewedBy value", func() {
+			It("Should return invalid proof error with nospace validation message", func() {
+				invalidInput := &api.ProofPatchInput{ReviewedBy: "Reviewer Name"}
+				before := fakeProofRepo.PatchProofByUriDigestCallCount()
+
+				err := proofSvc.PatchProofByUriDigest(context.TODO(), invalidInput, proof1Digest)
+
+				Expect(err).ToNot(BeNil())
+				Expect(errors.Is(err, apperrors.ErrInvalidProof)).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "reviewedby")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "nospace")).To(BeTrue())
+				Expect(fakeProofRepo.PatchProofByUriDigestCallCount()).To(Equal(before))
+			})
+		})
+
+		When("Patching a proof that does not exist", func() {
+			It("Should return proof not found error", func() {
+				fakeProofRepo.PatchProofByUriDigestReturns(gorm.ErrRecordNotFound)
+
+				patchInput := &api.ProofPatchInput{ReviewedBy: "ValidReviewer"}
+				err := proofSvc.PatchProofByUriDigest(context.TODO(), patchInput, "invalid-digest")
+
+				Expect(err).ToNot(BeNil())
+				Expect(errors.Is(err, apperrors.ErrProofNotFound)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("Proof DELETE validation tests", func() {
+		When("Deleting a proof that doesn't exist", func() {
+			It("Should return proof not found error", func() {
+				fakeProofRepo.GetProofByUriDigestReturns(nil, gorm.ErrRecordNotFound)
+				before := fakeProofRepo.DeleteProofByUriDigestCallCount()
+				getProofCalls := fakeProofRepo.GetProofByUriDigestCallCount()
+
+				err := proofSvc.DeleteProofByUriDigest(context.TODO(), "invalid-digest")
+
+				Expect(err).ToNot(BeNil())
+				Expect(errors.Is(err, apperrors.ErrProofNotFound)).To(BeTrue())
+				Expect(fakeProofRepo.DeleteProofByUriDigestCallCount()).To(Equal(before))
+				Expect(fakeProofRepo.GetProofByUriDigestCallCount()).To(Equal(getProofCalls + 1))
+			})
+		})
+	})
+
+	Context("Proof GET validation tests", func() {
+		When("Getting a proof that doesn't exist", func() {
+			It("Should return proof not found error", func() {
+				fakeProofRepo.GetProofByUriDigestReturns(nil, gorm.ErrRecordNotFound)
+				getProofCalls := fakeProofRepo.GetProofByUriDigestCallCount()
+
+				p, err := proofSvc.GetProofByUriDigest(context.TODO(), "invalid-digest")
+
+				Expect(p).To(BeNil())
+				Expect(err).ToNot(BeNil())
+				Expect(errors.Is(err, apperrors.ErrProofNotFound)).To(BeTrue())
+				Expect(fakeProofRepo.GetProofByUriDigestCallCount()).To(Equal(getProofCalls + 1))
 			})
 		})
 	})


### PR DESCRIPTION
Fixes: #67 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces validation for the Proof model and API, with clear 400/404 errors, and adds tests to lock the behavior. Fixes #67.

- New Features
  - Validate fields: ClaimUriDigest and ReviewedBy are required and cannot contain spaces; SupportsClaim is required; Uri must be an https URL.
  - Standardize not-found handling: return `apperrors.ErrProofNotFound`/404 in service and API; propagate `gorm.ErrRecordNotFound` from the repository.
  - Add acceptance and unit tests (POST/PATCH/DELETE/GET) to verify 400/404 responses and ensure no repository calls occur on invalid input.

<sup>Written for commit 178d4db5958bec105dc3a42d267da02a37be7e6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

