### PR TITLE
feat: adds claim validation endpoint

### DIFF
--- a/acceptance/claim_test.go
+++ b/acceptance/claim_test.go
@@ -225,6 +225,38 @@ var _ = Describe("Claim model tests", func() {
 			})
 		})
 
+		When("POST request is sent to verify a claim", func() {
+			It("should verify the claim and subsequent GET returns updated checked and validity fields", func() {
+				claimUrl, err := url.JoinPath(endpoint, claim2Digest)
+				Expect(err).To(BeNil())
+
+				// verify claim with validity true
+				validity := true
+				verifyBody := api.ClaimVerification{
+					Validity: &validity,
+				}
+				body, err := json.Marshal(verifyBody)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(claimUrl, "application/json", bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+
+				// verify the claim was updated
+				resp, err = http.Get(claimUrl)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				var c api.Claim
+				err = json.NewDecoder(resp.Body).Decode(&c)
+				Expect(err).To(BeNil())
+				Expect(c.Checked).To(BeTrue())
+				Expect(c.Validity).To(BeTrue())
+			})
+		})
+
 		When("DELETE request is sent to delete the created claim", func() {
 			It("should delete the created claim and subsequent GET returns 404", func() {
 				claimUrl, err := url.JoinPath(endpoint, claim1Digest)
@@ -415,5 +447,54 @@ var _ = Describe("Claim model tests", func() {
 				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("nonempty"))
 			})
 		})
+
+		When("POST request to verify claim without Validity field is sent", func() {
+			It("should return 400 with validation error mentioning validity", func() {
+				claimUrl, err := url.JoinPath(endpoint, claim2Digest)
+				Expect(err).To(BeNil())
+
+				verifyBody := api.ClaimVerification{
+				}
+				body, err := json.Marshal(verifyBody)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(claimUrl, "application/json", bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("validity"))
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("required"))
+			})
+		})
+
+		When("POST request to verify a non-existent claim is sent", func() {
+			It("should return 404 with claim not found error", func() {
+				claimUrl, err := url.JoinPath(endpoint, "doesnotexist")
+				Expect(err).To(BeNil())
+
+				validity := true
+				verifyBody := api.ClaimVerification{
+					Validity: &validity,
+				}
+				body, err := json.Marshal(verifyBody)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(claimUrl, "application/json", bytes.NewBuffer(body))
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+				var errResp map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&errResp)
+				Expect(err).To(BeNil())
+				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("claim not found"))
+			})
+		})
+
+		
 	})
 })

--- a/api/source-score.yaml
+++ b/api/source-score.yaml
@@ -194,6 +194,25 @@ paths:
         404:
           description: claim not found
 
+    post:
+      tags:
+      - claim
+      operationId: verifyClaim
+      parameters:
+      - in: path
+        name: uriDigest
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClaimVerification'
+      responses:
+        200:
+          description: claim verified
+
   # proof paths
   /api/v1/proofs:
     get:
@@ -543,3 +562,12 @@ components:
           x-oapi-codegen-extra-tags:
             binding: required
             validate: nonempty,nospace
+
+    ClaimVerification:
+      type: object
+      properties:
+        validity:
+          type: boolean
+          x-oapi-codegen-extra-tags:
+            binding: required
+            validate: nonempty

--- a/api/source-score.yaml
+++ b/api/source-score.yaml
@@ -36,6 +36,7 @@ paths:
       - source
       operationId: postSource
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -80,6 +81,7 @@ paths:
         schema:
           type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -128,6 +130,7 @@ paths:
       - claim
       operationId: postClaim
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -184,6 +187,7 @@ paths:
         schema:
           type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -205,13 +209,16 @@ paths:
         schema:
           type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/ClaimVerification'
       responses:
-        200:
+        204:
           description: claim verified
+        404:
+          description: claim not found
 
   # proof paths
   /api/v1/proofs:
@@ -235,6 +242,7 @@ paths:
       - proof
       operationId: postProof
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -291,6 +299,7 @@ paths:
         schema:
           type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/pkg/api/server.gen.go
+++ b/pkg/api/server.gen.go
@@ -36,6 +36,11 @@ type ClaimPatchInput struct {
 	Title   *string `json:"title" validate:"omitnil,nonempty"`
 }
 
+// ClaimVerification defines model for ClaimVerification.
+type ClaimVerification struct {
+	Validity *bool `binding:"required" json:"validity,omitempty" validate:"nonempty"`
+}
+
 // CreateSourceResponse defines model for CreateSourceResponse.
 type CreateSourceResponse struct {
 	UriDigest string `binding:"required" json:"uriDigest"`
@@ -99,6 +104,9 @@ type PostClaimJSONRequestBody = ClaimInput
 // PatchClaimJSONRequestBody defines body for PatchClaim for application/json ContentType.
 type PatchClaimJSONRequestBody = ClaimPatchInput
 
+// VerifyClaimJSONRequestBody defines body for VerifyClaim for application/json ContentType.
+type VerifyClaimJSONRequestBody = ClaimVerification
+
 // PostProofJSONRequestBody defines body for PostProof for application/json ContentType.
 type PostProofJSONRequestBody = ProofInput
 
@@ -125,6 +133,9 @@ type ServerInterface interface {
 
 	// (PATCH /api/v1/claim/{uriDigest})
 	PatchClaim(c *gin.Context, uriDigest string)
+
+	// (POST /api/v1/claim/{uriDigest})
+	VerifyClaim(c *gin.Context, uriDigest string)
 
 	// (GET /api/v1/claims)
 	GetClaims(c *gin.Context)
@@ -255,6 +266,30 @@ func (siw *ServerInterfaceWrapper) PatchClaim(c *gin.Context) {
 	}
 
 	siw.Handler.PatchClaim(c, uriDigest)
+}
+
+// VerifyClaim operation middleware
+func (siw *ServerInterfaceWrapper) VerifyClaim(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "uriDigest" -------------
+	var uriDigest string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "uriDigest", c.Param("uriDigest"), &uriDigest, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter uriDigest: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.VerifyClaim(c, uriDigest)
 }
 
 // GetClaims operation middleware
@@ -510,6 +545,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.DELETE(options.BaseURL+"/api/v1/claim/:uriDigest", wrapper.DeleteClaim)
 	router.GET(options.BaseURL+"/api/v1/claim/:uriDigest", wrapper.GetClaim)
 	router.PATCH(options.BaseURL+"/api/v1/claim/:uriDigest", wrapper.PatchClaim)
+	router.POST(options.BaseURL+"/api/v1/claim/:uriDigest", wrapper.VerifyClaim)
 	router.GET(options.BaseURL+"/api/v1/claims", wrapper.GetClaims)
 	router.POST(options.BaseURL+"/api/v1/proof", wrapper.PostProof)
 	router.DELETE(options.BaseURL+"/api/v1/proof/:uriDigest", wrapper.DeleteProof)

--- a/pkg/apperrors/apperrors.go
+++ b/pkg/apperrors/apperrors.go
@@ -3,11 +3,12 @@ package apperrors
 import "errors"
 
 var (
-	ErrInvalidSource   = errors.New("invalid source body")
-	ErrInvalidClaim    = errors.New("invalid claim body")
-	ErrInvalidProof    = errors.New("invalid proof body")
-	ErrSourceNotFound  = errors.New("source not found")
-	ErrClaimNotFound   = errors.New("claim not found")
-	ErrProofNotFound   = errors.New("proof not found")
-	ErrValidationLogic = errors.New("validation logic error")
+	ErrInvalidSource            = errors.New("invalid source body")
+	ErrInvalidClaim             = errors.New("invalid claim body")
+	ErrInvalidProof             = errors.New("invalid proof body")
+	ErrSourceNotFound           = errors.New("source not found")
+	ErrClaimNotFound            = errors.New("claim not found")
+	ErrProofNotFound            = errors.New("proof not found")
+	ErrValidationLogic          = errors.New("validation logic error")
+	ErrInvalidClaimVerification = errors.New("invalid claim verification body")
 )

--- a/pkg/domain/claim/claim_repository.go
+++ b/pkg/domain/claim/claim_repository.go
@@ -18,7 +18,7 @@ type ClaimRepository interface {
 	GetClaimByUriDigest(ctx context.Context, uriDigest string) (*api.Claim, error)
 	DeleteClaimByUriDigest(ctx context.Context, claim *api.Claim) error
 	PatchClaimByUriDigest(ctx context.Context, claimInput *api.ClaimPatchInput, uriDigest string) error
-	ValidateClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error
+	VerifyClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error
 }
 
 type claimRepository struct {
@@ -114,7 +114,7 @@ func (cr *claimRepository) PatchClaimByUriDigest(ctx context.Context, claimInput
 	return result.Error
 }
 
-func (cr *claimRepository) ValidateClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error {
+func (cr *claimRepository) VerifyClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error {
 	claim := &api.Claim{}
 	claim.UriDigest = uriDigest
 

--- a/pkg/domain/claim/claim_repository.go
+++ b/pkg/domain/claim/claim_repository.go
@@ -18,6 +18,7 @@ type ClaimRepository interface {
 	GetClaimByUriDigest(ctx context.Context, uriDigest string) (*api.Claim, error)
 	DeleteClaimByUriDigest(ctx context.Context, claim *api.Claim) error
 	PatchClaimByUriDigest(ctx context.Context, claimInput *api.ClaimPatchInput, uriDigest string) error
+	ValidateClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error
 }
 
 type claimRepository struct {
@@ -106,6 +107,24 @@ func (cr *claimRepository) PatchClaimByUriDigest(ctx context.Context, claimInput
 	if claimInput.Title != nil {
 		claim.Title = *claimInput.Title
 	}
+
+	result = cr.client.Update(ctx, claim)
+	slog.InfoContext(ctx, fmt.Sprintf("%d rows affected\n", result.RowsAffected))
+
+	return result.Error
+}
+
+func (cr *claimRepository) ValidateClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error {
+	claim := &api.Claim{}
+	claim.UriDigest = uriDigest
+
+	result := cr.client.FindFirst(ctx, claim)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	claim.Checked = true
+	claim.Validity = *claimVerification.Validity
 
 	result = cr.client.Update(ctx, claim)
 	slog.InfoContext(ctx, fmt.Sprintf("%d rows affected\n", result.RowsAffected))

--- a/pkg/domain/claim/claim_repository_test.go
+++ b/pkg/domain/claim/claim_repository_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Claim repository layer unit tests", func() {
 					Validity: &validity,
 				}
 
-				err := claimRepo.ValidateClaimByUriDigest(context.TODO(), verification, claim2Digest)
+				err := claimRepo.VerifyClaimByUriDigest(context.TODO(), verification, claim2Digest)
 				Expect(err).ToNot(HaveOccurred())
 
 				validated, err := claimRepo.GetClaimByUriDigest(context.TODO(), claim2Digest)
@@ -142,7 +142,7 @@ var _ = Describe("Claim repository layer unit tests", func() {
 				validity := true
 				verification := &api.ClaimVerification{Validity: &validity}
 
-				err := claimRepo.ValidateClaimByUriDigest(context.TODO(), verification, "doesnotexist")
+				err := claimRepo.VerifyClaimByUriDigest(context.TODO(), verification, "doesnotexist")
 				Expect(err).To(HaveOccurred())
 				Expect(errors.Is(err, gorm.ErrRecordNotFound)).To(BeTrue())
 			})

--- a/pkg/domain/claim/claim_repository_test.go
+++ b/pkg/domain/claim/claim_repository_test.go
@@ -97,6 +97,24 @@ var _ = Describe("Claim repository layer unit tests", func() {
 				Expect(errors.Is(err, gorm.ErrRecordNotFound)).To(BeTrue())
 			})
 		})
+
+		When("Validating a claim by its uri digest", func() {
+			It("Should update the claim's checked and validity fields", func() {
+				validity := true
+				verification := &api.ClaimVerification{
+					Validity: &validity,
+				}
+
+				err := claimRepo.ValidateClaimByUriDigest(context.TODO(), verification, claim2Digest)
+				Expect(err).ToNot(HaveOccurred())
+
+				validated, err := claimRepo.GetClaimByUriDigest(context.TODO(), claim2Digest)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(validated).ToNot(BeNil())
+				Expect(validated.Checked).To(BeTrue())
+				Expect(validated.Validity).To(BeTrue())
+			})
+		})
 	})
 
 	Context("Validation tests", func() {
@@ -114,6 +132,17 @@ var _ = Describe("Claim repository layer unit tests", func() {
 				patchInput := &api.ClaimPatchInput{Title: &newTitle}
 
 				err := claimRepo.PatchClaimByUriDigest(context.TODO(), patchInput, "doesnotexist")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, gorm.ErrRecordNotFound)).To(BeTrue())
+			})
+		})
+
+		When("Validating a non-existent claim by uri digest", func() {
+			It("Should return gorm.ErrRecordNotFound", func() {
+				validity := true
+				verification := &api.ClaimVerification{Validity: &validity}
+
+				err := claimRepo.ValidateClaimByUriDigest(context.TODO(), verification, "doesnotexist")
 				Expect(err).To(HaveOccurred())
 				Expect(errors.Is(err, gorm.ErrRecordNotFound)).To(BeTrue())
 			})

--- a/pkg/domain/claim/claim_service.go
+++ b/pkg/domain/claim/claim_service.go
@@ -21,7 +21,7 @@ type ClaimService interface {
 	GetClaimByUriDigest(ctx context.Context, uriDigest string) (*api.Claim, error)
 	DeleteClaimByUriDigest(ctx context.Context, uriDigest string) error
 	PatchClaimByUriDigest(ctx context.Context, claimInput *api.ClaimPatchInput, uriDigest string) error
-	ValidateClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error
+	VerifyClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error
 }
 
 type claimService struct {
@@ -112,7 +112,7 @@ func (svc *claimService) PostClaim(ctx context.Context, claimInput *api.ClaimInp
 	return svc.claimRepo.PostClaim(ctx, claimInput)
 }
 
-func (svc *claimService) ValidateClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error {
+func (svc *claimService) VerifyClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error {
 	err := claimValidate.Struct(claimVerification)
 	if err != nil {
 		if _, ok := err.(*validator.InvalidValidationError); ok {
@@ -128,7 +128,7 @@ func (svc *claimService) ValidateClaimByUriDigest(ctx context.Context, claimVeri
 		return fmt.Errorf("%w: %s", apperrors.ErrInvalidClaimVerification, combinedErrs)
 	}
 
-	err = svc.claimRepo.ValidateClaimByUriDigest(ctx, claimVerification, uriDigest)
+	err = svc.claimRepo.VerifyClaimByUriDigest(ctx, claimVerification, uriDigest)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return fmt.Errorf("%w: %s", apperrors.ErrClaimNotFound, err.Error())
 	}

--- a/pkg/domain/claim/claim_service.go
+++ b/pkg/domain/claim/claim_service.go
@@ -21,6 +21,7 @@ type ClaimService interface {
 	GetClaimByUriDigest(ctx context.Context, uriDigest string) (*api.Claim, error)
 	DeleteClaimByUriDigest(ctx context.Context, uriDigest string) error
 	PatchClaimByUriDigest(ctx context.Context, claimInput *api.ClaimPatchInput, uriDigest string) error
+	ValidateClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error
 }
 
 type claimService struct {
@@ -109,4 +110,27 @@ func (svc *claimService) PostClaim(ctx context.Context, claimInput *api.ClaimInp
 	}
 
 	return svc.claimRepo.PostClaim(ctx, claimInput)
+}
+
+func (svc *claimService) ValidateClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error {
+	err := claimValidate.Struct(claimVerification)
+	if err != nil {
+		if _, ok := err.(*validator.InvalidValidationError); ok {
+			return fmt.Errorf("%w: %s", apperrors.ErrValidationLogic, err.Error())
+		}
+		combinedErrs := ""
+		for _, e := range err.(validator.ValidationErrors) {
+			combinedErrs = fmt.Sprintf(
+				"%s\n%s validation failed for value %v with error %s", combinedErrs, e.Field(), e.Value(), e.Tag(),
+			)
+		}
+		combinedErrs = strings.TrimSpace(combinedErrs)
+		return fmt.Errorf("%w: %s", apperrors.ErrInvalidClaimVerification, combinedErrs)
+	}
+
+	err = svc.claimRepo.ValidateClaimByUriDigest(ctx, claimVerification, uriDigest)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return fmt.Errorf("%w: %s", apperrors.ErrClaimNotFound, err.Error())
+	}
+	return err
 }

--- a/pkg/domain/claim/claim_service_test.go
+++ b/pkg/domain/claim/claim_service_test.go
@@ -163,13 +163,13 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 					Validity: &validity,
 				}
 
-				before := fakeClaimRepo.ValidateClaimByUriDigestCallCount()
-				fakeClaimRepo.ValidateClaimByUriDigestReturns(nil)
+				before := fakeClaimRepo.VerifyClaimByUriDigestCallCount()
+				fakeClaimRepo.VerifyClaimByUriDigestReturns(nil)
 
-				err := claimSvc.ValidateClaimByUriDigest(context.TODO(), verification, claim2Digest)
+				err := claimSvc.VerifyClaimByUriDigest(context.TODO(), verification, claim2Digest)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(fakeClaimRepo.ValidateClaimByUriDigestCallCount()).To(Equal(before + 1))
-				_, argVerification, argDigest := fakeClaimRepo.ValidateClaimByUriDigestArgsForCall(before)
+				Expect(fakeClaimRepo.VerifyClaimByUriDigestCallCount()).To(Equal(before + 1))
+				_, argVerification, argDigest := fakeClaimRepo.VerifyClaimByUriDigestArgsForCall(before)
 				Expect(argDigest).To(Equal(claim2Digest))
 				Expect(argVerification.Validity).ToNot(BeNil())
 				Expect(*argVerification.Validity).To(BeFalse())
@@ -291,14 +291,14 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 				verification := &api.ClaimVerification{
 					Validity: nil,
 				}
-				before := fakeClaimRepo.ValidateClaimByUriDigestCallCount()
+				before := fakeClaimRepo.VerifyClaimByUriDigestCallCount()
 
-				err := claimSvc.ValidateClaimByUriDigest(context.TODO(), verification, claim1Digest)
+				err := claimSvc.VerifyClaimByUriDigest(context.TODO(), verification, claim1Digest)
 				Expect(err).To(HaveOccurred())
 				Expect(errors.Is(err, apperrors.ErrInvalidClaimVerification)).To(BeTrue())
 				Expect(strings.Contains(strings.ToLower(err.Error()), "validity")).To(BeTrue())
 				Expect(strings.Contains(strings.ToLower(err.Error()), "nonempty")).To(BeTrue())
-				Expect(fakeClaimRepo.ValidateClaimByUriDigestCallCount()).To(Equal(before))
+				Expect(fakeClaimRepo.VerifyClaimByUriDigestCallCount()).To(Equal(before))
 			})
 		})
 
@@ -306,13 +306,13 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 			It("Should return ErrClaimNotFound", func() {
 				validity := true
 				verification := &api.ClaimVerification{Validity: &validity}
-				before := fakeClaimRepo.ValidateClaimByUriDigestCallCount()
-				fakeClaimRepo.ValidateClaimByUriDigestReturns(gorm.ErrRecordNotFound)
+				before := fakeClaimRepo.VerifyClaimByUriDigestCallCount()
+				fakeClaimRepo.VerifyClaimByUriDigestReturns(gorm.ErrRecordNotFound)
 
-				err := claimSvc.ValidateClaimByUriDigest(context.TODO(), verification, "doesnotexist")
+				err := claimSvc.VerifyClaimByUriDigest(context.TODO(), verification, "doesnotexist")
 				Expect(err).To(HaveOccurred())
 				Expect(errors.Is(err, apperrors.ErrClaimNotFound)).To(BeTrue())
-				Expect(fakeClaimRepo.ValidateClaimByUriDigestCallCount()).To(Equal(before + 1))
+				Expect(fakeClaimRepo.VerifyClaimByUriDigestCallCount()).To(Equal(before + 1))
 			})
 		})
 	})

--- a/pkg/domain/claim/claim_service_test.go
+++ b/pkg/domain/claim/claim_service_test.go
@@ -155,6 +155,26 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 			})
 
 		})
+
+		When("Validating a claim by its uri digest", func() {
+			It("Should validate the claim via repository with validity false", func() {
+				validity := false
+				verification := &api.ClaimVerification{
+					Validity: &validity,
+				}
+
+				before := fakeClaimRepo.ValidateClaimByUriDigestCallCount()
+				fakeClaimRepo.ValidateClaimByUriDigestReturns(nil)
+
+				err := claimSvc.ValidateClaimByUriDigest(context.TODO(), verification, claim2Digest)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fakeClaimRepo.ValidateClaimByUriDigestCallCount()).To(Equal(before + 1))
+				_, argVerification, argDigest := fakeClaimRepo.ValidateClaimByUriDigestArgsForCall(before)
+				Expect(argDigest).To(Equal(claim2Digest))
+				Expect(argVerification.Validity).ToNot(BeNil())
+				Expect(*argVerification.Validity).To(BeFalse())
+			})
+		})
 	})
 
 	Context("Validation tests", func() {
@@ -266,5 +286,34 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 			})
 		})
 
+		When("Validating a claim without Validity field", func() {
+			It("Should return ErrInvalidClaimVerification and not call repo", func() {
+				verification := &api.ClaimVerification{
+					Validity: nil,
+				}
+				before := fakeClaimRepo.ValidateClaimByUriDigestCallCount()
+
+				err := claimSvc.ValidateClaimByUriDigest(context.TODO(), verification, claim1Digest)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, apperrors.ErrInvalidClaimVerification)).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "validity")).To(BeTrue())
+				Expect(strings.Contains(strings.ToLower(err.Error()), "nonempty")).To(BeTrue())
+				Expect(fakeClaimRepo.ValidateClaimByUriDigestCallCount()).To(Equal(before))
+			})
+		})
+
+		When("Validating a non-existent claim by uri digest", func() {
+			It("Should return ErrClaimNotFound", func() {
+				validity := true
+				verification := &api.ClaimVerification{Validity: &validity}
+				before := fakeClaimRepo.ValidateClaimByUriDigestCallCount()
+				fakeClaimRepo.ValidateClaimByUriDigestReturns(gorm.ErrRecordNotFound)
+
+				err := claimSvc.ValidateClaimByUriDigest(context.TODO(), verification, "doesnotexist")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, apperrors.ErrClaimNotFound)).To(BeTrue())
+				Expect(fakeClaimRepo.ValidateClaimByUriDigestCallCount()).To(Equal(before + 1))
+			})
+		})
 	})
 })

--- a/pkg/domain/claim/claimfakes/fake_claim_repository.go
+++ b/pkg/domain/claim/claimfakes/fake_claim_repository.go
@@ -75,6 +75,19 @@ type FakeClaimRepository struct {
 		result1 string
 		result2 error
 	}
+	ValidateClaimByUriDigestStub        func(context.Context, *api.ClaimVerification, string) error
+	validateClaimByUriDigestMutex       sync.RWMutex
+	validateClaimByUriDigestArgsForCall []struct {
+		arg1 context.Context
+		arg2 *api.ClaimVerification
+		arg3 string
+	}
+	validateClaimByUriDigestReturns struct {
+		result1 error
+	}
+	validateClaimByUriDigestReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -396,6 +409,69 @@ func (fake *FakeClaimRepository) PostClaimReturnsOnCall(i int, result1 string, r
 		result1 string
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeClaimRepository) ValidateClaimByUriDigest(arg1 context.Context, arg2 *api.ClaimVerification, arg3 string) error {
+	fake.validateClaimByUriDigestMutex.Lock()
+	ret, specificReturn := fake.validateClaimByUriDigestReturnsOnCall[len(fake.validateClaimByUriDigestArgsForCall)]
+	fake.validateClaimByUriDigestArgsForCall = append(fake.validateClaimByUriDigestArgsForCall, struct {
+		arg1 context.Context
+		arg2 *api.ClaimVerification
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.ValidateClaimByUriDigestStub
+	fakeReturns := fake.validateClaimByUriDigestReturns
+	fake.recordInvocation("ValidateClaimByUriDigest", []interface{}{arg1, arg2, arg3})
+	fake.validateClaimByUriDigestMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClaimRepository) ValidateClaimByUriDigestCallCount() int {
+	fake.validateClaimByUriDigestMutex.RLock()
+	defer fake.validateClaimByUriDigestMutex.RUnlock()
+	return len(fake.validateClaimByUriDigestArgsForCall)
+}
+
+func (fake *FakeClaimRepository) ValidateClaimByUriDigestCalls(stub func(context.Context, *api.ClaimVerification, string) error) {
+	fake.validateClaimByUriDigestMutex.Lock()
+	defer fake.validateClaimByUriDigestMutex.Unlock()
+	fake.ValidateClaimByUriDigestStub = stub
+}
+
+func (fake *FakeClaimRepository) ValidateClaimByUriDigestArgsForCall(i int) (context.Context, *api.ClaimVerification, string) {
+	fake.validateClaimByUriDigestMutex.RLock()
+	defer fake.validateClaimByUriDigestMutex.RUnlock()
+	argsForCall := fake.validateClaimByUriDigestArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeClaimRepository) ValidateClaimByUriDigestReturns(result1 error) {
+	fake.validateClaimByUriDigestMutex.Lock()
+	defer fake.validateClaimByUriDigestMutex.Unlock()
+	fake.ValidateClaimByUriDigestStub = nil
+	fake.validateClaimByUriDigestReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClaimRepository) ValidateClaimByUriDigestReturnsOnCall(i int, result1 error) {
+	fake.validateClaimByUriDigestMutex.Lock()
+	defer fake.validateClaimByUriDigestMutex.Unlock()
+	fake.ValidateClaimByUriDigestStub = nil
+	if fake.validateClaimByUriDigestReturnsOnCall == nil {
+		fake.validateClaimByUriDigestReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.validateClaimByUriDigestReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeClaimRepository) Invocations() map[string][][]interface{} {

--- a/pkg/domain/claim/claimfakes/fake_claim_repository.go
+++ b/pkg/domain/claim/claimfakes/fake_claim_repository.go
@@ -75,17 +75,17 @@ type FakeClaimRepository struct {
 		result1 string
 		result2 error
 	}
-	ValidateClaimByUriDigestStub        func(context.Context, *api.ClaimVerification, string) error
-	validateClaimByUriDigestMutex       sync.RWMutex
-	validateClaimByUriDigestArgsForCall []struct {
+	VerifyClaimByUriDigestStub        func(context.Context, *api.ClaimVerification, string) error
+	verifyClaimByUriDigestMutex       sync.RWMutex
+	verifyClaimByUriDigestArgsForCall []struct {
 		arg1 context.Context
 		arg2 *api.ClaimVerification
 		arg3 string
 	}
-	validateClaimByUriDigestReturns struct {
+	verifyClaimByUriDigestReturns struct {
 		result1 error
 	}
-	validateClaimByUriDigestReturnsOnCall map[int]struct {
+	verifyClaimByUriDigestReturnsOnCall map[int]struct {
 		result1 error
 	}
 	invocations      map[string][][]interface{}
@@ -411,18 +411,18 @@ func (fake *FakeClaimRepository) PostClaimReturnsOnCall(i int, result1 string, r
 	}{result1, result2}
 }
 
-func (fake *FakeClaimRepository) ValidateClaimByUriDigest(arg1 context.Context, arg2 *api.ClaimVerification, arg3 string) error {
-	fake.validateClaimByUriDigestMutex.Lock()
-	ret, specificReturn := fake.validateClaimByUriDigestReturnsOnCall[len(fake.validateClaimByUriDigestArgsForCall)]
-	fake.validateClaimByUriDigestArgsForCall = append(fake.validateClaimByUriDigestArgsForCall, struct {
+func (fake *FakeClaimRepository) VerifyClaimByUriDigest(arg1 context.Context, arg2 *api.ClaimVerification, arg3 string) error {
+	fake.verifyClaimByUriDigestMutex.Lock()
+	ret, specificReturn := fake.verifyClaimByUriDigestReturnsOnCall[len(fake.verifyClaimByUriDigestArgsForCall)]
+	fake.verifyClaimByUriDigestArgsForCall = append(fake.verifyClaimByUriDigestArgsForCall, struct {
 		arg1 context.Context
 		arg2 *api.ClaimVerification
 		arg3 string
 	}{arg1, arg2, arg3})
-	stub := fake.ValidateClaimByUriDigestStub
-	fakeReturns := fake.validateClaimByUriDigestReturns
-	fake.recordInvocation("ValidateClaimByUriDigest", []interface{}{arg1, arg2, arg3})
-	fake.validateClaimByUriDigestMutex.Unlock()
+	stub := fake.VerifyClaimByUriDigestStub
+	fakeReturns := fake.verifyClaimByUriDigestReturns
+	fake.recordInvocation("VerifyClaimByUriDigest", []interface{}{arg1, arg2, arg3})
+	fake.verifyClaimByUriDigestMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
 	}
@@ -432,44 +432,44 @@ func (fake *FakeClaimRepository) ValidateClaimByUriDigest(arg1 context.Context, 
 	return fakeReturns.result1
 }
 
-func (fake *FakeClaimRepository) ValidateClaimByUriDigestCallCount() int {
-	fake.validateClaimByUriDigestMutex.RLock()
-	defer fake.validateClaimByUriDigestMutex.RUnlock()
-	return len(fake.validateClaimByUriDigestArgsForCall)
+func (fake *FakeClaimRepository) VerifyClaimByUriDigestCallCount() int {
+	fake.verifyClaimByUriDigestMutex.RLock()
+	defer fake.verifyClaimByUriDigestMutex.RUnlock()
+	return len(fake.verifyClaimByUriDigestArgsForCall)
 }
 
-func (fake *FakeClaimRepository) ValidateClaimByUriDigestCalls(stub func(context.Context, *api.ClaimVerification, string) error) {
-	fake.validateClaimByUriDigestMutex.Lock()
-	defer fake.validateClaimByUriDigestMutex.Unlock()
-	fake.ValidateClaimByUriDigestStub = stub
+func (fake *FakeClaimRepository) VerifyClaimByUriDigestCalls(stub func(context.Context, *api.ClaimVerification, string) error) {
+	fake.verifyClaimByUriDigestMutex.Lock()
+	defer fake.verifyClaimByUriDigestMutex.Unlock()
+	fake.VerifyClaimByUriDigestStub = stub
 }
 
-func (fake *FakeClaimRepository) ValidateClaimByUriDigestArgsForCall(i int) (context.Context, *api.ClaimVerification, string) {
-	fake.validateClaimByUriDigestMutex.RLock()
-	defer fake.validateClaimByUriDigestMutex.RUnlock()
-	argsForCall := fake.validateClaimByUriDigestArgsForCall[i]
+func (fake *FakeClaimRepository) VerifyClaimByUriDigestArgsForCall(i int) (context.Context, *api.ClaimVerification, string) {
+	fake.verifyClaimByUriDigestMutex.RLock()
+	defer fake.verifyClaimByUriDigestMutex.RUnlock()
+	argsForCall := fake.verifyClaimByUriDigestArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeClaimRepository) ValidateClaimByUriDigestReturns(result1 error) {
-	fake.validateClaimByUriDigestMutex.Lock()
-	defer fake.validateClaimByUriDigestMutex.Unlock()
-	fake.ValidateClaimByUriDigestStub = nil
-	fake.validateClaimByUriDigestReturns = struct {
+func (fake *FakeClaimRepository) VerifyClaimByUriDigestReturns(result1 error) {
+	fake.verifyClaimByUriDigestMutex.Lock()
+	defer fake.verifyClaimByUriDigestMutex.Unlock()
+	fake.VerifyClaimByUriDigestStub = nil
+	fake.verifyClaimByUriDigestReturns = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *FakeClaimRepository) ValidateClaimByUriDigestReturnsOnCall(i int, result1 error) {
-	fake.validateClaimByUriDigestMutex.Lock()
-	defer fake.validateClaimByUriDigestMutex.Unlock()
-	fake.ValidateClaimByUriDigestStub = nil
-	if fake.validateClaimByUriDigestReturnsOnCall == nil {
-		fake.validateClaimByUriDigestReturnsOnCall = make(map[int]struct {
+func (fake *FakeClaimRepository) VerifyClaimByUriDigestReturnsOnCall(i int, result1 error) {
+	fake.verifyClaimByUriDigestMutex.Lock()
+	defer fake.verifyClaimByUriDigestMutex.Unlock()
+	fake.VerifyClaimByUriDigestStub = nil
+	if fake.verifyClaimByUriDigestReturnsOnCall == nil {
+		fake.verifyClaimByUriDigestReturnsOnCall = make(map[int]struct {
 			result1 error
 		})
 	}
-	fake.validateClaimByUriDigestReturnsOnCall[i] = struct {
+	fake.verifyClaimByUriDigestReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/pkg/domain/claim/claimfakes/fake_claim_service.go
+++ b/pkg/domain/claim/claimfakes/fake_claim_service.go
@@ -75,17 +75,17 @@ type FakeClaimService struct {
 		result1 string
 		result2 error
 	}
-	ValidateClaimByUriDigestStub        func(context.Context, *api.ClaimVerification, string) error
-	validateClaimByUriDigestMutex       sync.RWMutex
-	validateClaimByUriDigestArgsForCall []struct {
+	VerifyClaimByUriDigestStub        func(context.Context, *api.ClaimVerification, string) error
+	verifyClaimByUriDigestMutex       sync.RWMutex
+	verifyClaimByUriDigestArgsForCall []struct {
 		arg1 context.Context
 		arg2 *api.ClaimVerification
 		arg3 string
 	}
-	validateClaimByUriDigestReturns struct {
+	verifyClaimByUriDigestReturns struct {
 		result1 error
 	}
-	validateClaimByUriDigestReturnsOnCall map[int]struct {
+	verifyClaimByUriDigestReturnsOnCall map[int]struct {
 		result1 error
 	}
 	invocations      map[string][][]interface{}
@@ -411,18 +411,18 @@ func (fake *FakeClaimService) PostClaimReturnsOnCall(i int, result1 string, resu
 	}{result1, result2}
 }
 
-func (fake *FakeClaimService) ValidateClaimByUriDigest(arg1 context.Context, arg2 *api.ClaimVerification, arg3 string) error {
-	fake.validateClaimByUriDigestMutex.Lock()
-	ret, specificReturn := fake.validateClaimByUriDigestReturnsOnCall[len(fake.validateClaimByUriDigestArgsForCall)]
-	fake.validateClaimByUriDigestArgsForCall = append(fake.validateClaimByUriDigestArgsForCall, struct {
+func (fake *FakeClaimService) VerifyClaimByUriDigest(arg1 context.Context, arg2 *api.ClaimVerification, arg3 string) error {
+	fake.verifyClaimByUriDigestMutex.Lock()
+	ret, specificReturn := fake.verifyClaimByUriDigestReturnsOnCall[len(fake.verifyClaimByUriDigestArgsForCall)]
+	fake.verifyClaimByUriDigestArgsForCall = append(fake.verifyClaimByUriDigestArgsForCall, struct {
 		arg1 context.Context
 		arg2 *api.ClaimVerification
 		arg3 string
 	}{arg1, arg2, arg3})
-	stub := fake.ValidateClaimByUriDigestStub
-	fakeReturns := fake.validateClaimByUriDigestReturns
-	fake.recordInvocation("ValidateClaimByUriDigest", []interface{}{arg1, arg2, arg3})
-	fake.validateClaimByUriDigestMutex.Unlock()
+	stub := fake.VerifyClaimByUriDigestStub
+	fakeReturns := fake.verifyClaimByUriDigestReturns
+	fake.recordInvocation("VerifyClaimByUriDigest", []interface{}{arg1, arg2, arg3})
+	fake.verifyClaimByUriDigestMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
 	}
@@ -432,44 +432,44 @@ func (fake *FakeClaimService) ValidateClaimByUriDigest(arg1 context.Context, arg
 	return fakeReturns.result1
 }
 
-func (fake *FakeClaimService) ValidateClaimByUriDigestCallCount() int {
-	fake.validateClaimByUriDigestMutex.RLock()
-	defer fake.validateClaimByUriDigestMutex.RUnlock()
-	return len(fake.validateClaimByUriDigestArgsForCall)
+func (fake *FakeClaimService) VerifyClaimByUriDigestCallCount() int {
+	fake.verifyClaimByUriDigestMutex.RLock()
+	defer fake.verifyClaimByUriDigestMutex.RUnlock()
+	return len(fake.verifyClaimByUriDigestArgsForCall)
 }
 
-func (fake *FakeClaimService) ValidateClaimByUriDigestCalls(stub func(context.Context, *api.ClaimVerification, string) error) {
-	fake.validateClaimByUriDigestMutex.Lock()
-	defer fake.validateClaimByUriDigestMutex.Unlock()
-	fake.ValidateClaimByUriDigestStub = stub
+func (fake *FakeClaimService) VerifyClaimByUriDigestCalls(stub func(context.Context, *api.ClaimVerification, string) error) {
+	fake.verifyClaimByUriDigestMutex.Lock()
+	defer fake.verifyClaimByUriDigestMutex.Unlock()
+	fake.VerifyClaimByUriDigestStub = stub
 }
 
-func (fake *FakeClaimService) ValidateClaimByUriDigestArgsForCall(i int) (context.Context, *api.ClaimVerification, string) {
-	fake.validateClaimByUriDigestMutex.RLock()
-	defer fake.validateClaimByUriDigestMutex.RUnlock()
-	argsForCall := fake.validateClaimByUriDigestArgsForCall[i]
+func (fake *FakeClaimService) VerifyClaimByUriDigestArgsForCall(i int) (context.Context, *api.ClaimVerification, string) {
+	fake.verifyClaimByUriDigestMutex.RLock()
+	defer fake.verifyClaimByUriDigestMutex.RUnlock()
+	argsForCall := fake.verifyClaimByUriDigestArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeClaimService) ValidateClaimByUriDigestReturns(result1 error) {
-	fake.validateClaimByUriDigestMutex.Lock()
-	defer fake.validateClaimByUriDigestMutex.Unlock()
-	fake.ValidateClaimByUriDigestStub = nil
-	fake.validateClaimByUriDigestReturns = struct {
+func (fake *FakeClaimService) VerifyClaimByUriDigestReturns(result1 error) {
+	fake.verifyClaimByUriDigestMutex.Lock()
+	defer fake.verifyClaimByUriDigestMutex.Unlock()
+	fake.VerifyClaimByUriDigestStub = nil
+	fake.verifyClaimByUriDigestReturns = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *FakeClaimService) ValidateClaimByUriDigestReturnsOnCall(i int, result1 error) {
-	fake.validateClaimByUriDigestMutex.Lock()
-	defer fake.validateClaimByUriDigestMutex.Unlock()
-	fake.ValidateClaimByUriDigestStub = nil
-	if fake.validateClaimByUriDigestReturnsOnCall == nil {
-		fake.validateClaimByUriDigestReturnsOnCall = make(map[int]struct {
+func (fake *FakeClaimService) VerifyClaimByUriDigestReturnsOnCall(i int, result1 error) {
+	fake.verifyClaimByUriDigestMutex.Lock()
+	defer fake.verifyClaimByUriDigestMutex.Unlock()
+	fake.VerifyClaimByUriDigestStub = nil
+	if fake.verifyClaimByUriDigestReturnsOnCall == nil {
+		fake.verifyClaimByUriDigestReturnsOnCall = make(map[int]struct {
 			result1 error
 		})
 	}
-	fake.validateClaimByUriDigestReturnsOnCall[i] = struct {
+	fake.verifyClaimByUriDigestReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/pkg/domain/claim/claimfakes/fake_claim_service.go
+++ b/pkg/domain/claim/claimfakes/fake_claim_service.go
@@ -75,6 +75,19 @@ type FakeClaimService struct {
 		result1 string
 		result2 error
 	}
+	ValidateClaimByUriDigestStub        func(context.Context, *api.ClaimVerification, string) error
+	validateClaimByUriDigestMutex       sync.RWMutex
+	validateClaimByUriDigestArgsForCall []struct {
+		arg1 context.Context
+		arg2 *api.ClaimVerification
+		arg3 string
+	}
+	validateClaimByUriDigestReturns struct {
+		result1 error
+	}
+	validateClaimByUriDigestReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -396,6 +409,69 @@ func (fake *FakeClaimService) PostClaimReturnsOnCall(i int, result1 string, resu
 		result1 string
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeClaimService) ValidateClaimByUriDigest(arg1 context.Context, arg2 *api.ClaimVerification, arg3 string) error {
+	fake.validateClaimByUriDigestMutex.Lock()
+	ret, specificReturn := fake.validateClaimByUriDigestReturnsOnCall[len(fake.validateClaimByUriDigestArgsForCall)]
+	fake.validateClaimByUriDigestArgsForCall = append(fake.validateClaimByUriDigestArgsForCall, struct {
+		arg1 context.Context
+		arg2 *api.ClaimVerification
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.ValidateClaimByUriDigestStub
+	fakeReturns := fake.validateClaimByUriDigestReturns
+	fake.recordInvocation("ValidateClaimByUriDigest", []interface{}{arg1, arg2, arg3})
+	fake.validateClaimByUriDigestMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClaimService) ValidateClaimByUriDigestCallCount() int {
+	fake.validateClaimByUriDigestMutex.RLock()
+	defer fake.validateClaimByUriDigestMutex.RUnlock()
+	return len(fake.validateClaimByUriDigestArgsForCall)
+}
+
+func (fake *FakeClaimService) ValidateClaimByUriDigestCalls(stub func(context.Context, *api.ClaimVerification, string) error) {
+	fake.validateClaimByUriDigestMutex.Lock()
+	defer fake.validateClaimByUriDigestMutex.Unlock()
+	fake.ValidateClaimByUriDigestStub = stub
+}
+
+func (fake *FakeClaimService) ValidateClaimByUriDigestArgsForCall(i int) (context.Context, *api.ClaimVerification, string) {
+	fake.validateClaimByUriDigestMutex.RLock()
+	defer fake.validateClaimByUriDigestMutex.RUnlock()
+	argsForCall := fake.validateClaimByUriDigestArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeClaimService) ValidateClaimByUriDigestReturns(result1 error) {
+	fake.validateClaimByUriDigestMutex.Lock()
+	defer fake.validateClaimByUriDigestMutex.Unlock()
+	fake.ValidateClaimByUriDigestStub = nil
+	fake.validateClaimByUriDigestReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClaimService) ValidateClaimByUriDigestReturnsOnCall(i int, result1 error) {
+	fake.validateClaimByUriDigestMutex.Lock()
+	defer fake.validateClaimByUriDigestMutex.Unlock()
+	fake.ValidateClaimByUriDigestStub = nil
+	if fake.validateClaimByUriDigestReturnsOnCall == nil {
+		fake.validateClaimByUriDigestReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.validateClaimByUriDigestReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeClaimService) Invocations() map[string][][]interface{} {

--- a/pkg/handlers/claim.go
+++ b/pkg/handlers/claim.go
@@ -140,3 +140,37 @@ func (ch *ClaimHandler) PatchClaimByUriDigest(ctx *gin.Context, uriDigest string
 
 	ctx.Status(http.StatusNoContent)
 }
+
+func (ch *ClaimHandler) ValidateClaimByUriDigest(ctx *gin.Context, uriDigest string) {
+	claimVerification := &api.ClaimVerification{}
+	if err := ctx.ShouldBindJSON(claimVerification); err != nil {
+		ctx.JSON(
+			http.StatusBadRequest,
+			gin.H{"error": err.Error()},
+		)
+		return
+	}
+
+	if err := ch.claimSvc.VerifyClaimByUriDigest(ctx, claimVerification, uriDigest); err != nil {
+		switch {
+		case errors.Is(err, apperrors.ErrInvalidClaimVerification):
+			ctx.JSON(
+				http.StatusBadRequest,
+				gin.H{"error": err.Error()},
+			)
+		case errors.Is(err, apperrors.ErrClaimNotFound):
+			ctx.JSON(
+				http.StatusNotFound,
+				gin.H{"error": err.Error()},
+			)
+		default:
+			ctx.JSON(
+				http.StatusInternalServerError,
+				gin.H{"error": err.Error()},
+			)
+		}
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}

--- a/pkg/http/router.go
+++ b/pkg/http/router.go
@@ -78,6 +78,10 @@ func (r *router) PatchClaim(ctx *gin.Context, claimDigest string) {
 	r.claimHandler.PatchClaimByUriDigest(ctx, claimDigest)
 }
 
+func (r *router) VerifyClaim(ctx *gin.Context, claimDigest string) {
+	r.claimHandler.ValidateClaimByUriDigest(ctx, claimDigest)
+}
+
 func (r *router) PostProof(ctx *gin.Context) {
 	r.proofHandler.PostProof(ctx)
 }


### PR DESCRIPTION
Fixes: #69 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a POST endpoint to verify a claim by its digest. It marks the claim as checked, saves its validity, and returns clear 400/404 errors for bad input or missing claims.

- **New Features**
  - New endpoint: POST `/api/v1/claim/{uriDigest}` with body `{ "validity": boolean }`; returns 204 No Content on success.
  - Persists `checked = true` and `validity`; subsequent GET reflects the update.
  - Validates request body; returns 400 if `validity` is missing/invalid, 404 if the claim does not exist.
  - OpenAPI updated with `ClaimVerification` schema and operation; request bodies marked as required for Source/Claim/Proof create/patch routes.
  - Server, router, handler, service, and repository wired up; unit and acceptance tests cover success, missing `validity`, and not found.

<sup>Written for commit 504f3ed5e43feea6d93acc019471396f3ea3e6f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

