### PR TITLE
feat: adds endpoint to trigger source score calculation

### DIFF
--- a/acceptance/claim_test.go
+++ b/acceptance/claim_test.go
@@ -403,7 +403,7 @@ var _ = Describe("Claim model tests", func() {
 				}
 
 				// Hit the verify all claims endpoint
-				verifyAllUrl, err := url.JoinPath(baseUrl, "/api/v1/claims")
+				verifyAllUrl, err := url.JoinPath(baseUrl, "/api/v1/claims/verify")
 				Expect(err).To(BeNil())
 
 				resp, err = http.Post(verifyAllUrl, "application/json", nil)

--- a/acceptance/db/pg/01-tables.sql
+++ b/acceptance/db/pg/01-tables.sql
@@ -1,9 +1,9 @@
 CREATE TABLE
     sources (
         name TEXT,
-        score SMALLINT DEFAULT 0 CHECK (
+        score FLOAT DEFAULT 0 CHECK (
             score >= 0
-            AND score <= 100
+            AND score <= 1
         ),
         uri_digest TEXT PRIMARY KEY,
         summary TEXT,

--- a/acceptance/source_test.go
+++ b/acceptance/source_test.go
@@ -3,10 +3,12 @@ package acceptance_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"source-score/pkg/api"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -185,6 +187,173 @@ var _ = Describe("Source model tests", func() {
 				resp, err = http.Get(srcUrl)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			})
+		})
+
+		When("Updating all source scores based on checked claims", func() {
+			It("Should update source score to 0.5 when 1 valid and 1 invalid claim exist", func() {
+				// Create a new source
+				srcInput := api.SourceInput{
+					Name:    "Test Source for Score Update",
+					Summary: "sample summary",
+					Tags:    "tag99",
+					Uri:     "https://test-source-score-update",
+				}
+				srcBody, err := json.Marshal(srcInput)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(srcBody))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
+
+				var srcResp api.CreateSourceResponse
+				err = json.NewDecoder(resp.Body).Decode(&srcResp)
+				Expect(err).To(BeNil())
+				resp.Body.Close()
+
+				// Create claim endpoint
+				claimEndpoint, err := url.JoinPath(baseUrl, "/api/v1/claim")
+				Expect(err).To(BeNil())
+
+				// Create claim 1
+				claim1Input := api.ClaimInput{
+					SourceUriDigest: srcResp.UriDigest,
+					Summary:         "Test claim 1 for score update",
+					Title:           "Test Claim 1",
+					Uri:             "https://test-claim-score-1",
+				}
+				body1, err := json.Marshal(claim1Input)
+				Expect(err).To(BeNil())
+
+				resp, err = http.Post(claimEndpoint, "application/json", bytes.NewBuffer(body1))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
+
+				var respBody map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&respBody)
+				Expect(err).To(BeNil())
+				resp.Body.Close()
+				testClaim1Digest := respBody["uriDigest"]
+
+				// Create claim 2
+				claim2Input := api.ClaimInput{
+					SourceUriDigest: srcResp.UriDigest,
+					Summary:         "Test claim 2 for score update",
+					Title:           "Test Claim 2",
+					Uri:             "https://test-claim-score-2",
+				}
+				body2, err := json.Marshal(claim2Input)
+				Expect(err).To(BeNil())
+
+				resp, err = http.Post(claimEndpoint, "application/json", bytes.NewBuffer(body2))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
+
+				err = json.NewDecoder(resp.Body).Decode(&respBody)
+				Expect(err).To(BeNil())
+				resp.Body.Close()
+				testClaim2Digest := respBody["uriDigest"]
+
+				// Create claim 3 (no proofs)
+				claim3Input := api.ClaimInput{
+					SourceUriDigest: srcResp.UriDigest,
+					Summary:         "Test claim 3 for score update",
+					Title:           "Test Claim 3",
+					Uri:             "https://test-claim-score-3",
+				}
+				body3, err := json.Marshal(claim3Input)
+				Expect(err).To(BeNil())
+
+				resp, err = http.Post(claimEndpoint, "application/json", bytes.NewBuffer(body3))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
+				resp.Body.Close()
+
+				// Create proof for claim 1 (supporting = true)
+				proofEndpoint, err := url.JoinPath(baseUrl, "/api/v1/proof")
+				Expect(err).To(BeNil())
+
+				supports := true
+				proofInput := api.ProofInput{
+					ClaimUriDigest: testClaim1Digest,
+					ReviewedBy:     "ReviewerA",
+					SupportsClaim:  &supports,
+					Uri:            "https://proof-claim1-true",
+				}
+				proofBody, _ := json.Marshal(proofInput)
+				resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+				resp.Body.Close()
+
+				// Create proof for claim 2 (supporting = false)
+				supports = false
+				proofInput = api.ProofInput{
+					ClaimUriDigest: testClaim2Digest,
+					ReviewedBy:     "ReviewerB",
+					SupportsClaim:  &supports,
+					Uri:            "https://proof-claim2-false",
+				}
+				proofBody, _ = json.Marshal(proofInput)
+				resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+				resp.Body.Close()
+
+				// Hit the verify all claims endpoint
+				verifyAllUrl, err := url.JoinPath(baseUrl, "/api/v1/claims/verify")
+				Expect(err).To(BeNil())
+
+				resp, err = http.Post(verifyAllUrl, "application/json", nil)
+				Expect(err).To(BeNil())
+				resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+
+				// Loop until verify completes (no 409)
+				for {
+					resp, err = http.Post(verifyAllUrl, "application/json", nil)
+					Expect(err).To(BeNil())
+					resp.Body.Close()
+					if resp.StatusCode != http.StatusConflict {
+						break
+					}
+					time.Sleep(100 * time.Millisecond)
+				}
+
+				// Hit the update all scores endpoint
+				updateScoresUrl, err := url.JoinPath(baseUrl, "/api/v1/sources/scores")
+				Expect(err).To(BeNil())
+
+				resp, err = http.Post(updateScoresUrl, "application/json", nil)
+				Expect(err).To(BeNil())
+				resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+
+				// Loop until update scores completes (no 409)
+				for {
+					resp, err = http.Post(updateScoresUrl, "application/json", nil)
+					Expect(err).To(BeNil())
+					resp.Body.Close()
+					if resp.StatusCode != http.StatusConflict {
+						break
+					}
+					time.Sleep(100 * time.Millisecond)
+				}
+
+				// Get the source and verify score is 0.5
+				srcUrl, err := url.JoinPath(endpoint, srcResp.UriDigest)
+				Expect(err).To(BeNil())
+				resp, err = http.Get(srcUrl)
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				var src api.Source
+				err = json.NewDecoder(resp.Body).Decode(&src)
+				Expect(err).To(BeNil())
+				resp.Body.Close()
+
+				fmt.Printf("Source score: %f\n", src.Score)
+				Expect(src.Score).To(Equal(0.5))
 			})
 		})
 	})

--- a/api/source-score.yaml
+++ b/api/source-score.yaml
@@ -34,7 +34,7 @@ paths:
     post:
       tags:
       - sources
-      operationId: updateScores
+      operationId: updateAllScores
       responses:
         202:
           description: score update triggered

--- a/api/source-score.yaml
+++ b/api/source-score.yaml
@@ -30,6 +30,17 @@ paths:
                 items:
                   $ref: '#/components/schemas/Source'
 
+  /api/v1/sources/scores:
+    post:
+      tags:
+      - sources
+      operationId: updateScores
+      responses:
+        202:
+          description: score update triggered
+        409:
+          description: score calculation in progress
+
   /api/v1/source:
     post:
       tags:

--- a/api/source-score.yaml
+++ b/api/source-score.yaml
@@ -135,6 +135,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/Claim'
 
+  /api/v1/claims/verify:
     post:
       tags:
       - claims

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -68,7 +68,7 @@ func main() {
 	claimSvc := claim.NewClaimService(context.Background(), claimRepo, proofSvc)
 
 	srcRepo := source.NewSourceRepository(context.Background(), dbClient)
-	srcSvc := source.NewSourceService(context.Background(), srcRepo)
+	srcSvc := source.NewSourceService(context.Background(), srcRepo, claimRepo)
 
 	server := gin.Default()
 	api.RegisterHandlersWithOptions(

--- a/pkg/api/server.gen.go
+++ b/pkg/api/server.gen.go
@@ -173,6 +173,9 @@ type ServerInterface interface {
 	// (GET /api/v1/sources)
 	GetSources(c *gin.Context)
 
+	// (POST /api/v1/sources/scores)
+	UpdateScores(c *gin.Context)
+
 	// (GET /ping)
 	GetPing(c *gin.Context)
 }
@@ -517,6 +520,19 @@ func (siw *ServerInterfaceWrapper) GetSources(c *gin.Context) {
 	siw.Handler.GetSources(c)
 }
 
+// UpdateScores operation middleware
+func (siw *ServerInterfaceWrapper) UpdateScores(c *gin.Context) {
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.UpdateScores(c)
+}
+
 // GetPing operation middleware
 func (siw *ServerInterfaceWrapper) GetPing(c *gin.Context) {
 
@@ -574,5 +590,6 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/api/v1/source/:uriDigest", wrapper.GetSource)
 	router.PATCH(options.BaseURL+"/api/v1/source/:uriDigest", wrapper.PatchSource)
 	router.GET(options.BaseURL+"/api/v1/sources", wrapper.GetSources)
+	router.POST(options.BaseURL+"/api/v1/sources/scores", wrapper.UpdateScores)
 	router.GET(options.BaseURL+"/ping", wrapper.GetPing)
 }

--- a/pkg/api/server.gen.go
+++ b/pkg/api/server.gen.go
@@ -174,7 +174,7 @@ type ServerInterface interface {
 	GetSources(c *gin.Context)
 
 	// (POST /api/v1/sources/scores)
-	UpdateScores(c *gin.Context)
+	UpdateAllScores(c *gin.Context)
 
 	// (GET /ping)
 	GetPing(c *gin.Context)
@@ -520,8 +520,8 @@ func (siw *ServerInterfaceWrapper) GetSources(c *gin.Context) {
 	siw.Handler.GetSources(c)
 }
 
-// UpdateScores operation middleware
-func (siw *ServerInterfaceWrapper) UpdateScores(c *gin.Context) {
+// UpdateAllScores operation middleware
+func (siw *ServerInterfaceWrapper) UpdateAllScores(c *gin.Context) {
 
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
@@ -530,7 +530,7 @@ func (siw *ServerInterfaceWrapper) UpdateScores(c *gin.Context) {
 		}
 	}
 
-	siw.Handler.UpdateScores(c)
+	siw.Handler.UpdateAllScores(c)
 }
 
 // GetPing operation middleware
@@ -590,6 +590,6 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/api/v1/source/:uriDigest", wrapper.GetSource)
 	router.PATCH(options.BaseURL+"/api/v1/source/:uriDigest", wrapper.PatchSource)
 	router.GET(options.BaseURL+"/api/v1/sources", wrapper.GetSources)
-	router.POST(options.BaseURL+"/api/v1/sources/scores", wrapper.UpdateScores)
+	router.POST(options.BaseURL+"/api/v1/sources/scores", wrapper.UpdateAllScores)
 	router.GET(options.BaseURL+"/ping", wrapper.GetPing)
 }

--- a/pkg/api/server.gen.go
+++ b/pkg/api/server.gen.go
@@ -140,7 +140,7 @@ type ServerInterface interface {
 	// (GET /api/v1/claims)
 	GetClaims(c *gin.Context)
 
-	// (POST /api/v1/claims)
+	// (POST /api/v1/claims/verify)
 	VerifyAllClaims(c *gin.Context)
 
 	// (POST /api/v1/proof)
@@ -579,7 +579,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.PATCH(options.BaseURL+"/api/v1/claim/:uriDigest", wrapper.PatchClaim)
 	router.POST(options.BaseURL+"/api/v1/claim/:uriDigest", wrapper.VerifyClaim)
 	router.GET(options.BaseURL+"/api/v1/claims", wrapper.GetClaims)
-	router.POST(options.BaseURL+"/api/v1/claims", wrapper.VerifyAllClaims)
+	router.POST(options.BaseURL+"/api/v1/claims/verify", wrapper.VerifyAllClaims)
 	router.POST(options.BaseURL+"/api/v1/proof", wrapper.PostProof)
 	router.DELETE(options.BaseURL+"/api/v1/proof/:uriDigest", wrapper.DeleteProof)
 	router.GET(options.BaseURL+"/api/v1/proof/:uriDigest", wrapper.GetProof)

--- a/pkg/domain/claim/claim_repository.go
+++ b/pkg/domain/claim/claim_repository.go
@@ -21,6 +21,7 @@ type ClaimRepository interface {
 	PatchClaimByUriDigest(ctx context.Context, claimInput *api.ClaimPatchInput, uriDigest string) error
 	VerifyClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error
 	VerifyClaims(ctx context.Context, updatedClaims []api.Claim) error
+	GetClaimsBySources(ctx context.Context) (map[string][]api.Claim, error)
 }
 
 type claimRepository struct {
@@ -156,4 +157,23 @@ func (cr *claimRepository) VerifyClaims(ctx context.Context, updatedClaims []api
 
 	fmt.Printf("rows updated: %d\n", result.RowsAffected)
 	return nil
+}
+
+func (cr *claimRepository) GetClaimsBySources(ctx context.Context) (map[string][]api.Claim, error) {
+	srcClaims := make(map[string][]api.Claim)
+	allClaims, err := cr.GetClaims(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, claim := range allClaims {
+		if claims, ok := srcClaims[claim.SourceUriDigest]; ok {
+			srcClaims[claim.SourceUriDigest] = append(claims, claim)
+		} else {
+			srcClaims[claim.SourceUriDigest] = []api.Claim{claim}
+		}
+	}
+
+	return srcClaims, nil
 }

--- a/pkg/domain/claim/claim_repository.go
+++ b/pkg/domain/claim/claim_repository.go
@@ -20,8 +20,8 @@ type ClaimRepository interface {
 	DeleteClaimByUriDigest(ctx context.Context, claim *api.Claim) error
 	PatchClaimByUriDigest(ctx context.Context, claimInput *api.ClaimPatchInput, uriDigest string) error
 	VerifyClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error
-	VerifyClaims(ctx context.Context, updatedClaims []api.Claim) error
-	GetClaimsBySources(ctx context.Context) (map[string][]api.Claim, error)
+	VerifyAllClaims(ctx context.Context, updatedClaims []api.Claim) error
+	GetCheckedClaimsBySources(ctx context.Context) (map[string][]api.Claim, error)
 }
 
 type claimRepository struct {
@@ -135,7 +135,7 @@ func (cr *claimRepository) VerifyClaimByUriDigest(ctx context.Context, claimVeri
 	return result.Error
 }
 
-func (cr *claimRepository) VerifyClaims(ctx context.Context, updatedClaims []api.Claim) error {
+func (cr *claimRepository) VerifyAllClaims(ctx context.Context, updatedClaims []api.Claim) error {
 	var args []any
 	var query strings.Builder
 	claimDigests := []string{}
@@ -159,21 +159,23 @@ func (cr *claimRepository) VerifyClaims(ctx context.Context, updatedClaims []api
 	return nil
 }
 
-func (cr *claimRepository) GetClaimsBySources(ctx context.Context) (map[string][]api.Claim, error) {
-	srcClaims := make(map[string][]api.Claim)
-	allClaims, err := cr.GetClaims(ctx)
+func (cr *claimRepository) GetCheckedClaimsBySources(ctx context.Context) (map[string][]api.Claim, error) {
+	srcsClaims := make(map[string][]api.Claim)
+	var claims []api.Claim
 
-	if err != nil {
-		return nil, err
+	result := cr.client.DB.Where("checked = true").Find(&claims)
+
+	if result.Error != nil {
+		return nil, result.Error
 	}
 
-	for _, claim := range allClaims {
-		if claims, ok := srcClaims[claim.SourceUriDigest]; ok {
-			srcClaims[claim.SourceUriDigest] = append(claims, claim)
+	for _, claim := range claims {
+		if srcClaims, ok := srcsClaims[claim.SourceUriDigest]; ok {
+			srcsClaims[claim.SourceUriDigest] = append(srcClaims, claim)
 		} else {
-			srcClaims[claim.SourceUriDigest] = []api.Claim{claim}
+			srcsClaims[claim.SourceUriDigest] = []api.Claim{claim}
 		}
 	}
 
-	return srcClaims, nil
+	return srcsClaims, nil
 }

--- a/pkg/domain/claim/claim_repository_test.go
+++ b/pkg/domain/claim/claim_repository_test.go
@@ -3,6 +3,7 @@ package claim_test
 import (
 	"context"
 	"errors"
+	"time"
 
 	"source-score/pkg/api"
 
@@ -51,20 +52,6 @@ var _ = Describe("Claim repository layer unit tests", func() {
 					sampleClaim1,
 					sampleClaim2,
 				))
-			})
-		})
-
-		When("Getting claims grouped by sources", func() {
-			It("Should return a map of source uri digests to their claims", func() {
-				srcClaims, err := claimRepo.GetClaimsBySources(context.TODO())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(srcClaims).ToNot(BeNil())
-
-				// verify the map contains the source digest
-				claims, exists := srcClaims[srcDigest]
-				Expect(exists).To(BeTrue())
-				Expect(len(claims)).To(Equal(2))
-				Expect(claims).To(ContainElements(sampleClaim1, sampleClaim2))
 			})
 		})
 
@@ -164,7 +151,7 @@ var _ = Describe("Claim repository layer unit tests", func() {
 				}
 
 				// Call VerifyClaims
-				err = claimRepo.VerifyClaims(context.TODO(), updatedClaims)
+				err = claimRepo.VerifyAllClaims(context.TODO(), updatedClaims)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Verify claim 3 - should be checked=true, validity=true
@@ -190,6 +177,102 @@ var _ = Describe("Claim repository layer unit tests", func() {
 				Expect(claim5.Validity).To(BeFalse())
 				Expect(claim5.Title).To(Equal(claim5Input.Title))
 				Expect(claim5.Summary).To(Equal(claim5Input.Summary))
+			})
+		})
+
+		When("Getting checked claims grouped by sources", func() {
+			It("Should return only checked claims grouped by source uri digest", func() {
+				// Create a new source
+				newSource := api.Source{
+					Name:      "Test Source for GetCheckedClaims",
+					Score:     0,
+					Summary:   "Test source summary",
+					Tags:      "test-tag",
+					Uri:       "https://test-source-checked",
+					UriDigest: "test-source-digest-456",
+				}
+				result := testDB.Create(&newSource)
+				Expect(result.Error).ToNot(HaveOccurred())
+
+				// Create 2 claims
+				claim6Input := api.ClaimInput{
+					SourceUriDigest: newSource.UriDigest,
+					Summary:         "Test claim 6 summary",
+					Title:           "Test Claim 6",
+					Uri:             "https://test-claim-6",
+				}
+				digest6, err := claimRepo.PostClaim(context.TODO(), &claim6Input)
+				Expect(err).ToNot(HaveOccurred())
+
+				claim7Input := api.ClaimInput{
+					SourceUriDigest: newSource.UriDigest,
+					Summary:         "Test claim 7 summary",
+					Title:           "Test Claim 7",
+					Uri:             "https://test-claim-7",
+				}
+				digest7, err := claimRepo.PostClaim(context.TODO(), &claim7Input)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create 2 proofs for claim 6 (2 supporting, 0 refuting)
+				proof1 := api.Proof{
+					ClaimUriDigest: digest6,
+					ReviewedBy:     "ReviewerX",
+					SupportsClaim:  true,
+					Uri:            "https://proof-1-for-claim6",
+					UriDigest:      "proof1digest",
+				}
+				result = testDB.Create(&proof1)
+				Expect(result.Error).ToNot(HaveOccurred())
+
+				proof2 := api.Proof{
+					ClaimUriDigest: digest6,
+					ReviewedBy:     "ReviewerY",
+					SupportsClaim:  true,
+					Uri:            "https://proof-2-for-claim6",
+					UriDigest:      "proof2digest",
+				}
+				result = testDB.Create(&proof2)
+				Expect(result.Error).ToNot(HaveOccurred())
+
+				// Call VerifyClaims to mark claim 6 as checked
+				updatedClaims := []api.Claim{
+					{UriDigest: digest6, Validity: true},
+				}
+				err = claimRepo.VerifyAllClaims(context.TODO(), updatedClaims)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Eventually call GetCheckedClaimsBySources and verify claim 6 is present
+				Eventually(func() bool {
+					srcsClaims, err := claimRepo.GetCheckedClaimsBySources(context.TODO())
+					if err != nil {
+						return false
+					}
+
+					// Check if the source digest exists in the map
+					claims, exists := srcsClaims[newSource.UriDigest]
+					if !exists {
+						return false
+					}
+
+					// Check if claim 6 is in the list
+					for _, claim := range claims {
+						if claim.UriDigest == digest6 && claim.Checked == true {
+							return true
+						}
+					}
+					return false
+				}, 10*time.Second, 1*time.Second).Should(BeTrue())
+
+				// Verify claim 7 is NOT in the checked claims (it was not verified)
+				srcsClaims, err := claimRepo.GetCheckedClaimsBySources(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+
+				claims := srcsClaims[newSource.UriDigest]
+				provingClaim, err := claimRepo.GetClaimByUriDigest(context.TODO(), digest6)
+				uncheckedClaim, err := claimRepo.GetClaimByUriDigest(context.TODO(), digest7)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(claims).To(ContainElement(*provingClaim))
+				Expect(claims).ToNot(ContainElement(*uncheckedClaim))
 			})
 		})
 

--- a/pkg/domain/claim/claim_repository_test.go
+++ b/pkg/domain/claim/claim_repository_test.go
@@ -54,6 +54,20 @@ var _ = Describe("Claim repository layer unit tests", func() {
 			})
 		})
 
+		When("Getting claims grouped by sources", func() {
+			It("Should return a map of source uri digests to their claims", func() {
+				srcClaims, err := claimRepo.GetClaimsBySources(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(srcClaims).ToNot(BeNil())
+
+				// verify the map contains the source digest
+				claims, exists := srcClaims[srcDigest]
+				Expect(exists).To(BeTrue())
+				Expect(len(claims)).To(Equal(2))
+				Expect(claims).To(ContainElements(sampleClaim1, sampleClaim2))
+			})
+		})
+
 		When("Retrieving a single claim by uri digest", func() {
 			It("Should return the matching claim record", func() {
 				claim, err := claimRepo.GetClaimByUriDigest(context.TODO(), claim1Digest)
@@ -80,21 +94,6 @@ var _ = Describe("Claim repository layer unit tests", func() {
 				Expect(updated).ToNot(BeNil())
 				Expect(updated.Summary).To(Equal(newSummary))
 				Expect(updated.Title).To(Equal(newTitle))
-			})
-		})
-
-		When("Deleting a claim by its uri digest", func() {
-			It("Should delete the correct claim record from the DB", func() {
-				claim := &api.Claim{
-					UriDigest: claim1Digest,
-				}
-
-				err := claimRepo.DeleteClaimByUriDigest(context.TODO(), claim)
-				Expect(err).ToNot(HaveOccurred())
-
-				_, err = claimRepo.GetClaimByUriDigest(context.TODO(), claim1Digest)
-				Expect(err).To(HaveOccurred())
-				Expect(errors.Is(err, gorm.ErrRecordNotFound)).To(BeTrue())
 			})
 		})
 
@@ -191,6 +190,21 @@ var _ = Describe("Claim repository layer unit tests", func() {
 				Expect(claim5.Validity).To(BeFalse())
 				Expect(claim5.Title).To(Equal(claim5Input.Title))
 				Expect(claim5.Summary).To(Equal(claim5Input.Summary))
+			})
+		})
+
+		When("Deleting a claim by its uri digest", func() {
+			It("Should delete the correct claim record from the DB", func() {
+				claim := &api.Claim{
+					UriDigest: claim1Digest,
+				}
+
+				err := claimRepo.DeleteClaimByUriDigest(context.TODO(), claim)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = claimRepo.GetClaimByUriDigest(context.TODO(), claim1Digest)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, gorm.ErrRecordNotFound)).To(BeTrue())
 			})
 		})
 	})

--- a/pkg/domain/claim/claim_repository_test.go
+++ b/pkg/domain/claim/claim_repository_test.go
@@ -269,6 +269,7 @@ var _ = Describe("Claim repository layer unit tests", func() {
 
 				claims := srcsClaims[newSource.UriDigest]
 				provingClaim, err := claimRepo.GetClaimByUriDigest(context.TODO(), digest6)
+				Expect(err).ToNot(HaveOccurred())
 				uncheckedClaim, err := claimRepo.GetClaimByUriDigest(context.TODO(), digest7)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(claims).To(ContainElement(*provingClaim))

--- a/pkg/domain/claim/claim_service.go
+++ b/pkg/domain/claim/claim_service.go
@@ -179,7 +179,7 @@ func (svc *claimService) VerifyAllClaims(ctx context.Context) error {
 	}
 
 	if len(updatedClaims) > 0 {
-		err = svc.claimRepo.VerifyClaims(ctx, updatedClaims)
+		err = svc.claimRepo.VerifyAllClaims(ctx, updatedClaims)
 		if err != nil {
 			return err
 		}

--- a/pkg/domain/claim/claim_service_test.go
+++ b/pkg/domain/claim/claim_service_test.go
@@ -216,13 +216,13 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 				fakeProofSvc.GetProofsByClaimsReturns(claimsProofs, nil)
 				fakeClaimRepo.GetClaimByUriDigestReturnsOnCall(2, &claim1, nil)
 				fakeClaimRepo.GetClaimByUriDigestReturnsOnCall(3, &claim2, nil)
-				fakeClaimRepo.VerifyClaimsReturns(nil)
+				fakeClaimRepo.VerifyAllClaimsReturns(nil)
 
 				err := claimSvc.VerifyAllClaims(context.TODO())
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(fakeClaimRepo.VerifyClaimsCallCount()).To(Equal(1))
-				_, updatedClaims := fakeClaimRepo.VerifyClaimsArgsForCall(0)
+				Expect(fakeClaimRepo.VerifyAllClaimsCallCount()).To(Equal(1))
+				_, updatedClaims := fakeClaimRepo.VerifyAllClaimsArgsForCall(0)
 				Expect(len(updatedClaims)).To(Equal(2))
 
 				var updatedClaim1, updatedClaim2 *api.Claim

--- a/pkg/domain/claim/claim_suite_test.go
+++ b/pkg/domain/claim/claim_suite_test.go
@@ -62,7 +62,7 @@ func TestClaim(t *testing.T) {
 		testDB, err = gorm.Open(sqlite.Open(testDBFile))
 		Expect(err).ToNot(HaveOccurred())
 
-		err = testDB.AutoMigrate(&api.Source{}, &api.Claim{})
+		err = testDB.AutoMigrate(&api.Source{}, &api.Claim{}, &api.Proof{})
 		Expect(err).ToNot(HaveOccurred())
 
 		result := testDB.Create(&sampleSource)

--- a/pkg/domain/claim/claimfakes/fake_claim_repository.go
+++ b/pkg/domain/claim/claimfakes/fake_claim_repository.go
@@ -21,6 +21,19 @@ type FakeClaimRepository struct {
 	deleteClaimByUriDigestReturnsOnCall map[int]struct {
 		result1 error
 	}
+	GetCheckedClaimsBySourcesStub        func(context.Context) (map[string][]api.Claim, error)
+	getCheckedClaimsBySourcesMutex       sync.RWMutex
+	getCheckedClaimsBySourcesArgsForCall []struct {
+		arg1 context.Context
+	}
+	getCheckedClaimsBySourcesReturns struct {
+		result1 map[string][]api.Claim
+		result2 error
+	}
+	getCheckedClaimsBySourcesReturnsOnCall map[int]struct {
+		result1 map[string][]api.Claim
+		result2 error
+	}
 	GetClaimByUriDigestStub        func(context.Context, string) (*api.Claim, error)
 	getClaimByUriDigestMutex       sync.RWMutex
 	getClaimByUriDigestArgsForCall []struct {
@@ -46,19 +59,6 @@ type FakeClaimRepository struct {
 	}
 	getClaimsReturnsOnCall map[int]struct {
 		result1 []api.Claim
-		result2 error
-	}
-	GetClaimsBySourcesStub        func(context.Context) (map[string][]api.Claim, error)
-	getClaimsBySourcesMutex       sync.RWMutex
-	getClaimsBySourcesArgsForCall []struct {
-		arg1 context.Context
-	}
-	getClaimsBySourcesReturns struct {
-		result1 map[string][]api.Claim
-		result2 error
-	}
-	getClaimsBySourcesReturnsOnCall map[int]struct {
-		result1 map[string][]api.Claim
 		result2 error
 	}
 	PatchClaimByUriDigestStub        func(context.Context, *api.ClaimPatchInput, string) error
@@ -88,6 +88,18 @@ type FakeClaimRepository struct {
 		result1 string
 		result2 error
 	}
+	VerifyAllClaimsStub        func(context.Context, []api.Claim) error
+	verifyAllClaimsMutex       sync.RWMutex
+	verifyAllClaimsArgsForCall []struct {
+		arg1 context.Context
+		arg2 []api.Claim
+	}
+	verifyAllClaimsReturns struct {
+		result1 error
+	}
+	verifyAllClaimsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	VerifyClaimByUriDigestStub        func(context.Context, *api.ClaimVerification, string) error
 	verifyClaimByUriDigestMutex       sync.RWMutex
 	verifyClaimByUriDigestArgsForCall []struct {
@@ -99,18 +111,6 @@ type FakeClaimRepository struct {
 		result1 error
 	}
 	verifyClaimByUriDigestReturnsOnCall map[int]struct {
-		result1 error
-	}
-	VerifyClaimsStub        func(context.Context, []api.Claim) error
-	verifyClaimsMutex       sync.RWMutex
-	verifyClaimsArgsForCall []struct {
-		arg1 context.Context
-		arg2 []api.Claim
-	}
-	verifyClaimsReturns struct {
-		result1 error
-	}
-	verifyClaimsReturnsOnCall map[int]struct {
 		result1 error
 	}
 	invocations      map[string][][]interface{}
@@ -177,6 +177,70 @@ func (fake *FakeClaimRepository) DeleteClaimByUriDigestReturnsOnCall(i int, resu
 	fake.deleteClaimByUriDigestReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeClaimRepository) GetCheckedClaimsBySources(arg1 context.Context) (map[string][]api.Claim, error) {
+	fake.getCheckedClaimsBySourcesMutex.Lock()
+	ret, specificReturn := fake.getCheckedClaimsBySourcesReturnsOnCall[len(fake.getCheckedClaimsBySourcesArgsForCall)]
+	fake.getCheckedClaimsBySourcesArgsForCall = append(fake.getCheckedClaimsBySourcesArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.GetCheckedClaimsBySourcesStub
+	fakeReturns := fake.getCheckedClaimsBySourcesReturns
+	fake.recordInvocation("GetCheckedClaimsBySources", []interface{}{arg1})
+	fake.getCheckedClaimsBySourcesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClaimRepository) GetCheckedClaimsBySourcesCallCount() int {
+	fake.getCheckedClaimsBySourcesMutex.RLock()
+	defer fake.getCheckedClaimsBySourcesMutex.RUnlock()
+	return len(fake.getCheckedClaimsBySourcesArgsForCall)
+}
+
+func (fake *FakeClaimRepository) GetCheckedClaimsBySourcesCalls(stub func(context.Context) (map[string][]api.Claim, error)) {
+	fake.getCheckedClaimsBySourcesMutex.Lock()
+	defer fake.getCheckedClaimsBySourcesMutex.Unlock()
+	fake.GetCheckedClaimsBySourcesStub = stub
+}
+
+func (fake *FakeClaimRepository) GetCheckedClaimsBySourcesArgsForCall(i int) context.Context {
+	fake.getCheckedClaimsBySourcesMutex.RLock()
+	defer fake.getCheckedClaimsBySourcesMutex.RUnlock()
+	argsForCall := fake.getCheckedClaimsBySourcesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClaimRepository) GetCheckedClaimsBySourcesReturns(result1 map[string][]api.Claim, result2 error) {
+	fake.getCheckedClaimsBySourcesMutex.Lock()
+	defer fake.getCheckedClaimsBySourcesMutex.Unlock()
+	fake.GetCheckedClaimsBySourcesStub = nil
+	fake.getCheckedClaimsBySourcesReturns = struct {
+		result1 map[string][]api.Claim
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClaimRepository) GetCheckedClaimsBySourcesReturnsOnCall(i int, result1 map[string][]api.Claim, result2 error) {
+	fake.getCheckedClaimsBySourcesMutex.Lock()
+	defer fake.getCheckedClaimsBySourcesMutex.Unlock()
+	fake.GetCheckedClaimsBySourcesStub = nil
+	if fake.getCheckedClaimsBySourcesReturnsOnCall == nil {
+		fake.getCheckedClaimsBySourcesReturnsOnCall = make(map[int]struct {
+			result1 map[string][]api.Claim
+			result2 error
+		})
+	}
+	fake.getCheckedClaimsBySourcesReturnsOnCall[i] = struct {
+		result1 map[string][]api.Claim
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeClaimRepository) GetClaimByUriDigest(arg1 context.Context, arg2 string) (*api.Claim, error) {
@@ -304,70 +368,6 @@ func (fake *FakeClaimRepository) GetClaimsReturnsOnCall(i int, result1 []api.Cla
 	}
 	fake.getClaimsReturnsOnCall[i] = struct {
 		result1 []api.Claim
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClaimRepository) GetClaimsBySources(arg1 context.Context) (map[string][]api.Claim, error) {
-	fake.getClaimsBySourcesMutex.Lock()
-	ret, specificReturn := fake.getClaimsBySourcesReturnsOnCall[len(fake.getClaimsBySourcesArgsForCall)]
-	fake.getClaimsBySourcesArgsForCall = append(fake.getClaimsBySourcesArgsForCall, struct {
-		arg1 context.Context
-	}{arg1})
-	stub := fake.GetClaimsBySourcesStub
-	fakeReturns := fake.getClaimsBySourcesReturns
-	fake.recordInvocation("GetClaimsBySources", []interface{}{arg1})
-	fake.getClaimsBySourcesMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeClaimRepository) GetClaimsBySourcesCallCount() int {
-	fake.getClaimsBySourcesMutex.RLock()
-	defer fake.getClaimsBySourcesMutex.RUnlock()
-	return len(fake.getClaimsBySourcesArgsForCall)
-}
-
-func (fake *FakeClaimRepository) GetClaimsBySourcesCalls(stub func(context.Context) (map[string][]api.Claim, error)) {
-	fake.getClaimsBySourcesMutex.Lock()
-	defer fake.getClaimsBySourcesMutex.Unlock()
-	fake.GetClaimsBySourcesStub = stub
-}
-
-func (fake *FakeClaimRepository) GetClaimsBySourcesArgsForCall(i int) context.Context {
-	fake.getClaimsBySourcesMutex.RLock()
-	defer fake.getClaimsBySourcesMutex.RUnlock()
-	argsForCall := fake.getClaimsBySourcesArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeClaimRepository) GetClaimsBySourcesReturns(result1 map[string][]api.Claim, result2 error) {
-	fake.getClaimsBySourcesMutex.Lock()
-	defer fake.getClaimsBySourcesMutex.Unlock()
-	fake.GetClaimsBySourcesStub = nil
-	fake.getClaimsBySourcesReturns = struct {
-		result1 map[string][]api.Claim
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClaimRepository) GetClaimsBySourcesReturnsOnCall(i int, result1 map[string][]api.Claim, result2 error) {
-	fake.getClaimsBySourcesMutex.Lock()
-	defer fake.getClaimsBySourcesMutex.Unlock()
-	fake.GetClaimsBySourcesStub = nil
-	if fake.getClaimsBySourcesReturnsOnCall == nil {
-		fake.getClaimsBySourcesReturnsOnCall = make(map[int]struct {
-			result1 map[string][]api.Claim
-			result2 error
-		})
-	}
-	fake.getClaimsBySourcesReturnsOnCall[i] = struct {
-		result1 map[string][]api.Claim
 		result2 error
 	}{result1, result2}
 }
@@ -500,6 +500,73 @@ func (fake *FakeClaimRepository) PostClaimReturnsOnCall(i int, result1 string, r
 	}{result1, result2}
 }
 
+func (fake *FakeClaimRepository) VerifyAllClaims(arg1 context.Context, arg2 []api.Claim) error {
+	var arg2Copy []api.Claim
+	if arg2 != nil {
+		arg2Copy = make([]api.Claim, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.verifyAllClaimsMutex.Lock()
+	ret, specificReturn := fake.verifyAllClaimsReturnsOnCall[len(fake.verifyAllClaimsArgsForCall)]
+	fake.verifyAllClaimsArgsForCall = append(fake.verifyAllClaimsArgsForCall, struct {
+		arg1 context.Context
+		arg2 []api.Claim
+	}{arg1, arg2Copy})
+	stub := fake.VerifyAllClaimsStub
+	fakeReturns := fake.verifyAllClaimsReturns
+	fake.recordInvocation("VerifyAllClaims", []interface{}{arg1, arg2Copy})
+	fake.verifyAllClaimsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClaimRepository) VerifyAllClaimsCallCount() int {
+	fake.verifyAllClaimsMutex.RLock()
+	defer fake.verifyAllClaimsMutex.RUnlock()
+	return len(fake.verifyAllClaimsArgsForCall)
+}
+
+func (fake *FakeClaimRepository) VerifyAllClaimsCalls(stub func(context.Context, []api.Claim) error) {
+	fake.verifyAllClaimsMutex.Lock()
+	defer fake.verifyAllClaimsMutex.Unlock()
+	fake.VerifyAllClaimsStub = stub
+}
+
+func (fake *FakeClaimRepository) VerifyAllClaimsArgsForCall(i int) (context.Context, []api.Claim) {
+	fake.verifyAllClaimsMutex.RLock()
+	defer fake.verifyAllClaimsMutex.RUnlock()
+	argsForCall := fake.verifyAllClaimsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeClaimRepository) VerifyAllClaimsReturns(result1 error) {
+	fake.verifyAllClaimsMutex.Lock()
+	defer fake.verifyAllClaimsMutex.Unlock()
+	fake.VerifyAllClaimsStub = nil
+	fake.verifyAllClaimsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClaimRepository) VerifyAllClaimsReturnsOnCall(i int, result1 error) {
+	fake.verifyAllClaimsMutex.Lock()
+	defer fake.verifyAllClaimsMutex.Unlock()
+	fake.VerifyAllClaimsStub = nil
+	if fake.verifyAllClaimsReturnsOnCall == nil {
+		fake.verifyAllClaimsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.verifyAllClaimsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeClaimRepository) VerifyClaimByUriDigest(arg1 context.Context, arg2 *api.ClaimVerification, arg3 string) error {
 	fake.verifyClaimByUriDigestMutex.Lock()
 	ret, specificReturn := fake.verifyClaimByUriDigestReturnsOnCall[len(fake.verifyClaimByUriDigestArgsForCall)]
@@ -559,73 +626,6 @@ func (fake *FakeClaimRepository) VerifyClaimByUriDigestReturnsOnCall(i int, resu
 		})
 	}
 	fake.verifyClaimByUriDigestReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClaimRepository) VerifyClaims(arg1 context.Context, arg2 []api.Claim) error {
-	var arg2Copy []api.Claim
-	if arg2 != nil {
-		arg2Copy = make([]api.Claim, len(arg2))
-		copy(arg2Copy, arg2)
-	}
-	fake.verifyClaimsMutex.Lock()
-	ret, specificReturn := fake.verifyClaimsReturnsOnCall[len(fake.verifyClaimsArgsForCall)]
-	fake.verifyClaimsArgsForCall = append(fake.verifyClaimsArgsForCall, struct {
-		arg1 context.Context
-		arg2 []api.Claim
-	}{arg1, arg2Copy})
-	stub := fake.VerifyClaimsStub
-	fakeReturns := fake.verifyClaimsReturns
-	fake.recordInvocation("VerifyClaims", []interface{}{arg1, arg2Copy})
-	fake.verifyClaimsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeClaimRepository) VerifyClaimsCallCount() int {
-	fake.verifyClaimsMutex.RLock()
-	defer fake.verifyClaimsMutex.RUnlock()
-	return len(fake.verifyClaimsArgsForCall)
-}
-
-func (fake *FakeClaimRepository) VerifyClaimsCalls(stub func(context.Context, []api.Claim) error) {
-	fake.verifyClaimsMutex.Lock()
-	defer fake.verifyClaimsMutex.Unlock()
-	fake.VerifyClaimsStub = stub
-}
-
-func (fake *FakeClaimRepository) VerifyClaimsArgsForCall(i int) (context.Context, []api.Claim) {
-	fake.verifyClaimsMutex.RLock()
-	defer fake.verifyClaimsMutex.RUnlock()
-	argsForCall := fake.verifyClaimsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeClaimRepository) VerifyClaimsReturns(result1 error) {
-	fake.verifyClaimsMutex.Lock()
-	defer fake.verifyClaimsMutex.Unlock()
-	fake.VerifyClaimsStub = nil
-	fake.verifyClaimsReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClaimRepository) VerifyClaimsReturnsOnCall(i int, result1 error) {
-	fake.verifyClaimsMutex.Lock()
-	defer fake.verifyClaimsMutex.Unlock()
-	fake.VerifyClaimsStub = nil
-	if fake.verifyClaimsReturnsOnCall == nil {
-		fake.verifyClaimsReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.verifyClaimsReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/pkg/domain/claim/claimfakes/fake_claim_repository.go
+++ b/pkg/domain/claim/claimfakes/fake_claim_repository.go
@@ -48,6 +48,19 @@ type FakeClaimRepository struct {
 		result1 []api.Claim
 		result2 error
 	}
+	GetClaimsBySourcesStub        func(context.Context) (map[string][]api.Claim, error)
+	getClaimsBySourcesMutex       sync.RWMutex
+	getClaimsBySourcesArgsForCall []struct {
+		arg1 context.Context
+	}
+	getClaimsBySourcesReturns struct {
+		result1 map[string][]api.Claim
+		result2 error
+	}
+	getClaimsBySourcesReturnsOnCall map[int]struct {
+		result1 map[string][]api.Claim
+		result2 error
+	}
 	PatchClaimByUriDigestStub        func(context.Context, *api.ClaimPatchInput, string) error
 	patchClaimByUriDigestMutex       sync.RWMutex
 	patchClaimByUriDigestArgsForCall []struct {
@@ -291,6 +304,70 @@ func (fake *FakeClaimRepository) GetClaimsReturnsOnCall(i int, result1 []api.Cla
 	}
 	fake.getClaimsReturnsOnCall[i] = struct {
 		result1 []api.Claim
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClaimRepository) GetClaimsBySources(arg1 context.Context) (map[string][]api.Claim, error) {
+	fake.getClaimsBySourcesMutex.Lock()
+	ret, specificReturn := fake.getClaimsBySourcesReturnsOnCall[len(fake.getClaimsBySourcesArgsForCall)]
+	fake.getClaimsBySourcesArgsForCall = append(fake.getClaimsBySourcesArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.GetClaimsBySourcesStub
+	fakeReturns := fake.getClaimsBySourcesReturns
+	fake.recordInvocation("GetClaimsBySources", []interface{}{arg1})
+	fake.getClaimsBySourcesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClaimRepository) GetClaimsBySourcesCallCount() int {
+	fake.getClaimsBySourcesMutex.RLock()
+	defer fake.getClaimsBySourcesMutex.RUnlock()
+	return len(fake.getClaimsBySourcesArgsForCall)
+}
+
+func (fake *FakeClaimRepository) GetClaimsBySourcesCalls(stub func(context.Context) (map[string][]api.Claim, error)) {
+	fake.getClaimsBySourcesMutex.Lock()
+	defer fake.getClaimsBySourcesMutex.Unlock()
+	fake.GetClaimsBySourcesStub = stub
+}
+
+func (fake *FakeClaimRepository) GetClaimsBySourcesArgsForCall(i int) context.Context {
+	fake.getClaimsBySourcesMutex.RLock()
+	defer fake.getClaimsBySourcesMutex.RUnlock()
+	argsForCall := fake.getClaimsBySourcesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClaimRepository) GetClaimsBySourcesReturns(result1 map[string][]api.Claim, result2 error) {
+	fake.getClaimsBySourcesMutex.Lock()
+	defer fake.getClaimsBySourcesMutex.Unlock()
+	fake.GetClaimsBySourcesStub = nil
+	fake.getClaimsBySourcesReturns = struct {
+		result1 map[string][]api.Claim
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClaimRepository) GetClaimsBySourcesReturnsOnCall(i int, result1 map[string][]api.Claim, result2 error) {
+	fake.getClaimsBySourcesMutex.Lock()
+	defer fake.getClaimsBySourcesMutex.Unlock()
+	fake.GetClaimsBySourcesStub = nil
+	if fake.getClaimsBySourcesReturnsOnCall == nil {
+		fake.getClaimsBySourcesReturnsOnCall = make(map[int]struct {
+			result1 map[string][]api.Claim
+			result2 error
+		})
+	}
+	fake.getClaimsBySourcesReturnsOnCall[i] = struct {
+		result1 map[string][]api.Claim
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/domain/source/source_repository.go
+++ b/pkg/domain/source/source_repository.go
@@ -124,14 +124,13 @@ func (sr *sourceRepository) PatchSourceByUriDigest(ctx context.Context, sourceIn
 }
 
 func (sr *sourceRepository) UpdateAllScores(ctx context.Context, updatedSources *[]api.Source) error {
-	// TODO: validate the array before this layer
 	var args []any
 	var query strings.Builder
 	srcDigests := []string{}
 	query.WriteString("UPDATE sources SET score = CASE uri_digest")
 
 	for _, src := range *updatedSources {
-		query.WriteString(" WHEN ? THEN ?")
+		query.WriteString(" WHEN ? THEN CAST(? AS FLOAT)")
 		args = append(args, src.UriDigest, fmt.Sprintf("%f", src.Score))
 		srcDigests = append(srcDigests, src.UriDigest)
 	}

--- a/pkg/domain/source/source_repository.go
+++ b/pkg/domain/source/source_repository.go
@@ -19,7 +19,7 @@ type SourceRepository interface {
 	GetSourceByUriDigest(ctx context.Context, uriDigest string) (*api.Source, error)
 	PostSource(ctx context.Context, sourceInput *api.SourceInput) (string, error)
 	PatchSourceByUriDigest(ctx context.Context, sourceInput *api.SourcePatchInput, uriDigest string) error
-	UpdateSourceScores(ctx context.Context, updatedSources *[]api.Source) error
+	UpdateAllScores(ctx context.Context, updatedSources *[]api.Source) error
 }
 
 type sourceRepository struct {
@@ -123,7 +123,7 @@ func (sr *sourceRepository) PatchSourceByUriDigest(ctx context.Context, sourceIn
 	return result.Error
 }
 
-func (sr *sourceRepository) UpdateSourceScores(ctx context.Context, updatedSources *[]api.Source) error {
+func (sr *sourceRepository) UpdateAllScores(ctx context.Context, updatedSources *[]api.Source) error {
 	// TODO: validate the array before this layer
 	var args []any
 	var query strings.Builder

--- a/pkg/domain/source/source_repository.go
+++ b/pkg/domain/source/source_repository.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"source-score/pkg/api"
 	"source-score/pkg/db/pgsql"
@@ -18,6 +19,7 @@ type SourceRepository interface {
 	GetSourceByUriDigest(ctx context.Context, uriDigest string) (*api.Source, error)
 	PostSource(ctx context.Context, sourceInput *api.SourceInput) (string, error)
 	PatchSourceByUriDigest(ctx context.Context, sourceInput *api.SourcePatchInput, uriDigest string) error
+	UpdateSourceScores(ctx context.Context, updatedSources *[]api.Source) error
 }
 
 type sourceRepository struct {
@@ -119,4 +121,29 @@ func (sr *sourceRepository) PatchSourceByUriDigest(ctx context.Context, sourceIn
 	)
 
 	return result.Error
+}
+
+func (sr *sourceRepository) UpdateSourceScores(ctx context.Context, updatedSources *[]api.Source) error {
+	// TODO: validate the array before this layer
+	var args []any
+	var query strings.Builder
+	srcDigests := []string{}
+	query.WriteString("UPDATE sources SET score = CASE uri_digest")
+
+	for _, src := range *updatedSources {
+		query.WriteString(" WHEN ? THEN ?")
+		args = append(args, src.UriDigest, fmt.Sprintf("%f", src.Score))
+		srcDigests = append(srcDigests, src.UriDigest)
+	}
+
+	query.WriteString(" END WHERE uri_digest IN ?")
+	args = append(args, srcDigests)
+
+	result := sr.client.DB.Exec(query.String(), args...)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	fmt.Printf("rows updated: %d\n", result.RowsAffected)
+	return nil
 }

--- a/pkg/domain/source/source_repository_test.go
+++ b/pkg/domain/source/source_repository_test.go
@@ -109,6 +109,69 @@ var _ = Describe("Source model repository layer unit tests", Ordered, func() {
 				Expect(err.Error()).To(ContainSubstring("record not found"))
 			})
 		})
+
+		When("Updating scores for multiple sources", func() {
+			It("Should update only the score field for all provided sources", func() {
+				// Create 3 new sources
+				source5Input := api.SourceInput{
+					Name:    "Sample Source 5",
+					Summary: "Sample summary 5",
+					Tags:    "tag3",
+					Uri:     "https://sample-uri-5",
+				}
+				digest5, err := sourceRepo.PostSource(context.TODO(), &source5Input)
+				Expect(err).ToNot(HaveOccurred())
+
+				source6Input := api.SourceInput{
+					Name:    "Sample Source 6",
+					Summary: "Sample summary 6",
+					Tags:    "tag4",
+					Uri:     "https://sample-uri-6",
+				}
+				digest6, err := sourceRepo.PostSource(context.TODO(), &source6Input)
+				Expect(err).ToNot(HaveOccurred())
+
+				source7Input := api.SourceInput{
+					Name:    "Sample Source 7",
+					Summary: "Sample summary 7",
+					Tags:    "tag5",
+					Uri:     "https://sample-uri-7",
+				}
+				digest7, err := sourceRepo.PostSource(context.TODO(), &source7Input)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Prepare updated sources with new scores
+				updatedSources := []api.Source{
+					{UriDigest: digest5, Score: 0.4},
+					{UriDigest: digest6, Score: 1},
+					{UriDigest: digest7, Score: 0},
+				}
+
+				// Update scores
+				err = sourceRepo.UpdateSourceScores(context.TODO(), &updatedSources)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify scores were updated
+				src5, err := sourceRepo.GetSourceByUriDigest(context.TODO(), digest5)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(src5.Score).To(Equal(updatedSources[0].Score))
+				Expect(src5.Name).To(Equal(source5Input.Name))
+				Expect(src5.Summary).To(Equal(source5Input.Summary))
+
+				src6, err := sourceRepo.GetSourceByUriDigest(context.TODO(), digest6)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(src6.Score).To(Equal(updatedSources[1].Score))
+				Expect(src6.Name).To(Equal(source6Input.Name))
+				Expect(src6.Summary).To(Equal(source6Input.Summary))
+
+				src7, err := sourceRepo.GetSourceByUriDigest(context.TODO(), digest7)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(src7.Score).To(Equal(updatedSources[2].Score))
+				Expect(src7.Name).To(Equal(source7Input.Name))
+				Expect(src7.Summary).To(Equal(source7Input.Summary))
+			})
+		})
+
 	})
 
 	Context("Validation tests", func() {

--- a/pkg/domain/source/source_repository_test.go
+++ b/pkg/domain/source/source_repository_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Source model repository layer unit tests", Ordered, func() {
 				}
 
 				// Update scores
-				err = sourceRepo.UpdateSourceScores(context.TODO(), &updatedSources)
+				err = sourceRepo.UpdateAllScores(context.TODO(), &updatedSources)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Verify scores were updated

--- a/pkg/domain/source/source_service.go
+++ b/pkg/domain/source/source_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"source-score/pkg/api"
 	"source-score/pkg/apperrors"
+	"source-score/pkg/domain/claim"
 	"strings"
 
 	"source-score/pkg/helpers"
@@ -18,16 +19,19 @@ var (
 	validate = validator.New()
 )
 
+//go:generate go tool counterfeiter . SourceService
 type SourceService interface {
 	DeleteSourceByUriDigest(ctx context.Context, uriDigest string) error
 	GetSources(ctx context.Context) ([]api.Source, error)
 	GetSourceByUriDigest(ctx context.Context, uriDigest string) (*api.Source, error)
 	PostSource(ctx context.Context, sourceInput *api.SourceInput) (string, error)
 	PatchSourceByUriDigest(ctx context.Context, sourceInput *api.SourcePatchInput, uriDigest string) error
+	UpdateAllScores(ctx context.Context) error
 }
 
 type sourceService struct {
 	sourceRepo SourceRepository
+	claimRepo  claim.ClaimRepository
 }
 
 func init() {
@@ -114,4 +118,37 @@ func (svc *sourceService) PatchSourceByUriDigest(ctx context.Context, sourceInpu
 		return fmt.Errorf("%w: %s", apperrors.ErrSourceNotFound, err.Error())
 	}
 	return err
+}
+
+func (svc *sourceService) UpdateAllScores(ctx context.Context) error {
+	srcsClaims, err := svc.claimRepo.GetCheckedClaimsBySources(ctx)
+	if err != nil {
+		return err
+	}
+
+	var updatedSources []api.Source
+	for src, claims := range srcsClaims {
+		totalCtr := len(claims)
+		trueCtr := 0
+
+		for _, claim := range claims {
+			if claim.Validity {
+				trueCtr += 1
+			}
+		}
+
+		source, err := svc.sourceRepo.GetSourceByUriDigest(ctx, src)
+		if err != nil {
+			return err
+		}
+
+		source.Score = float64(trueCtr) / float64(totalCtr)
+		updatedSources = append(updatedSources, *source)
+	}
+
+	if len(updatedSources) > 0 {
+		return svc.sourceRepo.UpdateAllScores(ctx, &updatedSources)
+	}
+
+	return nil
 }

--- a/pkg/domain/source/source_service.go
+++ b/pkg/domain/source/source_service.go
@@ -46,9 +46,10 @@ func init() {
 	}
 }
 
-func NewSourceService(ctx context.Context, sourceRepo SourceRepository) SourceService {
+func NewSourceService(ctx context.Context, sourceRepo SourceRepository, claimRepo claim.ClaimRepository) SourceService {
 	return &sourceService{
 		sourceRepo: sourceRepo,
+		claimRepo:  claimRepo,
 	}
 }
 

--- a/pkg/domain/source/source_service_test.go
+++ b/pkg/domain/source/source_service_test.go
@@ -98,6 +98,65 @@ var _ = Describe("Source model service layer unit test", Ordered, func() {
 				Expect(*src).To(Equal(updatedSource))
 			})
 		})
+
+		When("Updating all source scores based on checked claims", func() {
+			It("Should calculate and update scores based on claim validity", func() {
+				// Create a new source
+				testSource := api.Source{
+					Name:      "Test Source for Score Update",
+					Score:     0,
+					Summary:   "Test source",
+					Tags:      "test",
+					Uri:       "https://test-source",
+					UriDigest: "test-source-digest",
+				}
+
+				// Create 2 checked claims: 1 with validity=true, 1 with validity=false
+				claim2 := api.Claim{
+					UriDigest:       "claim2-digest",
+					SourceUriDigest: testSource.UriDigest,
+					Title:           "Claim 2",
+					Summary:         "Checked claim - valid",
+					Checked:         true,
+					Validity:        true,
+				}
+
+				claim3 := api.Claim{
+					UriDigest:       "claim3-digest",
+					SourceUriDigest: testSource.UriDigest,
+					Title:           "Claim 3",
+					Summary:         "Checked claim - invalid",
+					Checked:         true,
+					Validity:        false,
+				}
+
+				// Mock GetCheckedClaimsBySources to return only checked claims
+				checkedClaimsMap := map[string][]api.Claim{
+					testSource.UriDigest: {claim2, claim3},
+				}
+				fakeClaimRepo.GetCheckedClaimsBySourcesReturns(checkedClaimsMap, nil)
+
+				// Mock GetSourceByUriDigest to return the test source
+				callCount := fakeSourceRepo.GetSourceByUriDigestCallCount()
+				fakeSourceRepo.GetSourceByUriDigestReturnsOnCall(callCount, &testSource, nil)
+
+				// Mock UpdateAllScores
+				fakeSourceRepo.UpdateAllScoresReturns(nil)
+
+				// Call UpdateAllScores
+				err := sourceSvc.UpdateAllScores(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify UpdateAllScores was called
+				Expect(fakeSourceRepo.UpdateAllScoresCallCount()).To(Equal(1))
+
+				// Verify the source score was updated to 0.5 (1 valid out of 2 checked claims)
+				_, updatedSources := fakeSourceRepo.UpdateAllScoresArgsForCall(0)
+				Expect(len(*updatedSources)).To(Equal(1))
+				Expect((*updatedSources)[0].UriDigest).To(Equal(testSource.UriDigest))
+				Expect((*updatedSources)[0].Score).To(Equal(0.5))
+			})
+		})
 	})
 
 	Context("Source POST validation tests", func() {

--- a/pkg/domain/source/source_suite_test.go
+++ b/pkg/domain/source/source_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"source-score/pkg/api"
 	"source-score/pkg/db/pgsql"
+	"source-score/pkg/domain/claim/claimfakes"
 	"source-score/pkg/domain/source"
 	"source-score/pkg/domain/source/sourcefakes"
 	"source-score/pkg/helpers"
@@ -36,6 +37,7 @@ var (
 
 	// fakes
 	fakeSourceRepo = sourcefakes.FakeSourceRepository{}
+	fakeClaimRepo  = claimfakes.FakeClaimRepository{}
 )
 
 func TestSource(t *testing.T) {
@@ -82,7 +84,7 @@ func TestSource(t *testing.T) {
 		sourceRepo = source.NewSourceRepository(context.TODO(), &pgsql.Client{
 			DB: testDB,
 		})
-		sourceSvc = source.NewSourceService(context.TODO(), &fakeSourceRepo)
+		sourceSvc = source.NewSourceService(context.TODO(), &fakeSourceRepo, &fakeClaimRepo)
 	})
 
 	var _ = AfterSuite(func() {

--- a/pkg/domain/source/sourcefakes/fake_source_repository.go
+++ b/pkg/domain/source/sourcefakes/fake_source_repository.go
@@ -75,6 +75,18 @@ type FakeSourceRepository struct {
 		result1 string
 		result2 error
 	}
+	UpdateSourceScoresStub        func(context.Context, *[]api.Source) error
+	updateSourceScoresMutex       sync.RWMutex
+	updateSourceScoresArgsForCall []struct {
+		arg1 context.Context
+		arg2 *[]api.Source
+	}
+	updateSourceScoresReturns struct {
+		result1 error
+	}
+	updateSourceScoresReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -396,6 +408,68 @@ func (fake *FakeSourceRepository) PostSourceReturnsOnCall(i int, result1 string,
 		result1 string
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeSourceRepository) UpdateSourceScores(arg1 context.Context, arg2 *[]api.Source) error {
+	fake.updateSourceScoresMutex.Lock()
+	ret, specificReturn := fake.updateSourceScoresReturnsOnCall[len(fake.updateSourceScoresArgsForCall)]
+	fake.updateSourceScoresArgsForCall = append(fake.updateSourceScoresArgsForCall, struct {
+		arg1 context.Context
+		arg2 *[]api.Source
+	}{arg1, arg2})
+	stub := fake.UpdateSourceScoresStub
+	fakeReturns := fake.updateSourceScoresReturns
+	fake.recordInvocation("UpdateSourceScores", []interface{}{arg1, arg2})
+	fake.updateSourceScoresMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeSourceRepository) UpdateSourceScoresCallCount() int {
+	fake.updateSourceScoresMutex.RLock()
+	defer fake.updateSourceScoresMutex.RUnlock()
+	return len(fake.updateSourceScoresArgsForCall)
+}
+
+func (fake *FakeSourceRepository) UpdateSourceScoresCalls(stub func(context.Context, *[]api.Source) error) {
+	fake.updateSourceScoresMutex.Lock()
+	defer fake.updateSourceScoresMutex.Unlock()
+	fake.UpdateSourceScoresStub = stub
+}
+
+func (fake *FakeSourceRepository) UpdateSourceScoresArgsForCall(i int) (context.Context, *[]api.Source) {
+	fake.updateSourceScoresMutex.RLock()
+	defer fake.updateSourceScoresMutex.RUnlock()
+	argsForCall := fake.updateSourceScoresArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeSourceRepository) UpdateSourceScoresReturns(result1 error) {
+	fake.updateSourceScoresMutex.Lock()
+	defer fake.updateSourceScoresMutex.Unlock()
+	fake.UpdateSourceScoresStub = nil
+	fake.updateSourceScoresReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeSourceRepository) UpdateSourceScoresReturnsOnCall(i int, result1 error) {
+	fake.updateSourceScoresMutex.Lock()
+	defer fake.updateSourceScoresMutex.Unlock()
+	fake.UpdateSourceScoresStub = nil
+	if fake.updateSourceScoresReturnsOnCall == nil {
+		fake.updateSourceScoresReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateSourceScoresReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeSourceRepository) Invocations() map[string][][]interface{} {

--- a/pkg/domain/source/sourcefakes/fake_source_service.go
+++ b/pkg/domain/source/sourcefakes/fake_source_service.go
@@ -8,12 +8,12 @@ import (
 	"sync"
 )
 
-type FakeSourceRepository struct {
-	DeleteSourceByUriDigestStub        func(context.Context, *api.Source) error
+type FakeSourceService struct {
+	DeleteSourceByUriDigestStub        func(context.Context, string) error
 	deleteSourceByUriDigestMutex       sync.RWMutex
 	deleteSourceByUriDigestArgsForCall []struct {
 		arg1 context.Context
-		arg2 *api.Source
+		arg2 string
 	}
 	deleteSourceByUriDigestReturns struct {
 		result1 error
@@ -75,11 +75,10 @@ type FakeSourceRepository struct {
 		result1 string
 		result2 error
 	}
-	UpdateAllScoresStub        func(context.Context, *[]api.Source) error
+	UpdateAllScoresStub        func(context.Context) error
 	updateAllScoresMutex       sync.RWMutex
 	updateAllScoresArgsForCall []struct {
 		arg1 context.Context
-		arg2 *[]api.Source
 	}
 	updateAllScoresReturns struct {
 		result1 error
@@ -91,12 +90,12 @@ type FakeSourceRepository struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeSourceRepository) DeleteSourceByUriDigest(arg1 context.Context, arg2 *api.Source) error {
+func (fake *FakeSourceService) DeleteSourceByUriDigest(arg1 context.Context, arg2 string) error {
 	fake.deleteSourceByUriDigestMutex.Lock()
 	ret, specificReturn := fake.deleteSourceByUriDigestReturnsOnCall[len(fake.deleteSourceByUriDigestArgsForCall)]
 	fake.deleteSourceByUriDigestArgsForCall = append(fake.deleteSourceByUriDigestArgsForCall, struct {
 		arg1 context.Context
-		arg2 *api.Source
+		arg2 string
 	}{arg1, arg2})
 	stub := fake.DeleteSourceByUriDigestStub
 	fakeReturns := fake.deleteSourceByUriDigestReturns
@@ -111,26 +110,26 @@ func (fake *FakeSourceRepository) DeleteSourceByUriDigest(arg1 context.Context, 
 	return fakeReturns.result1
 }
 
-func (fake *FakeSourceRepository) DeleteSourceByUriDigestCallCount() int {
+func (fake *FakeSourceService) DeleteSourceByUriDigestCallCount() int {
 	fake.deleteSourceByUriDigestMutex.RLock()
 	defer fake.deleteSourceByUriDigestMutex.RUnlock()
 	return len(fake.deleteSourceByUriDigestArgsForCall)
 }
 
-func (fake *FakeSourceRepository) DeleteSourceByUriDigestCalls(stub func(context.Context, *api.Source) error) {
+func (fake *FakeSourceService) DeleteSourceByUriDigestCalls(stub func(context.Context, string) error) {
 	fake.deleteSourceByUriDigestMutex.Lock()
 	defer fake.deleteSourceByUriDigestMutex.Unlock()
 	fake.DeleteSourceByUriDigestStub = stub
 }
 
-func (fake *FakeSourceRepository) DeleteSourceByUriDigestArgsForCall(i int) (context.Context, *api.Source) {
+func (fake *FakeSourceService) DeleteSourceByUriDigestArgsForCall(i int) (context.Context, string) {
 	fake.deleteSourceByUriDigestMutex.RLock()
 	defer fake.deleteSourceByUriDigestMutex.RUnlock()
 	argsForCall := fake.deleteSourceByUriDigestArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeSourceRepository) DeleteSourceByUriDigestReturns(result1 error) {
+func (fake *FakeSourceService) DeleteSourceByUriDigestReturns(result1 error) {
 	fake.deleteSourceByUriDigestMutex.Lock()
 	defer fake.deleteSourceByUriDigestMutex.Unlock()
 	fake.DeleteSourceByUriDigestStub = nil
@@ -139,7 +138,7 @@ func (fake *FakeSourceRepository) DeleteSourceByUriDigestReturns(result1 error) 
 	}{result1}
 }
 
-func (fake *FakeSourceRepository) DeleteSourceByUriDigestReturnsOnCall(i int, result1 error) {
+func (fake *FakeSourceService) DeleteSourceByUriDigestReturnsOnCall(i int, result1 error) {
 	fake.deleteSourceByUriDigestMutex.Lock()
 	defer fake.deleteSourceByUriDigestMutex.Unlock()
 	fake.DeleteSourceByUriDigestStub = nil
@@ -153,7 +152,7 @@ func (fake *FakeSourceRepository) DeleteSourceByUriDigestReturnsOnCall(i int, re
 	}{result1}
 }
 
-func (fake *FakeSourceRepository) GetSourceByUriDigest(arg1 context.Context, arg2 string) (*api.Source, error) {
+func (fake *FakeSourceService) GetSourceByUriDigest(arg1 context.Context, arg2 string) (*api.Source, error) {
 	fake.getSourceByUriDigestMutex.Lock()
 	ret, specificReturn := fake.getSourceByUriDigestReturnsOnCall[len(fake.getSourceByUriDigestArgsForCall)]
 	fake.getSourceByUriDigestArgsForCall = append(fake.getSourceByUriDigestArgsForCall, struct {
@@ -173,26 +172,26 @@ func (fake *FakeSourceRepository) GetSourceByUriDigest(arg1 context.Context, arg
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeSourceRepository) GetSourceByUriDigestCallCount() int {
+func (fake *FakeSourceService) GetSourceByUriDigestCallCount() int {
 	fake.getSourceByUriDigestMutex.RLock()
 	defer fake.getSourceByUriDigestMutex.RUnlock()
 	return len(fake.getSourceByUriDigestArgsForCall)
 }
 
-func (fake *FakeSourceRepository) GetSourceByUriDigestCalls(stub func(context.Context, string) (*api.Source, error)) {
+func (fake *FakeSourceService) GetSourceByUriDigestCalls(stub func(context.Context, string) (*api.Source, error)) {
 	fake.getSourceByUriDigestMutex.Lock()
 	defer fake.getSourceByUriDigestMutex.Unlock()
 	fake.GetSourceByUriDigestStub = stub
 }
 
-func (fake *FakeSourceRepository) GetSourceByUriDigestArgsForCall(i int) (context.Context, string) {
+func (fake *FakeSourceService) GetSourceByUriDigestArgsForCall(i int) (context.Context, string) {
 	fake.getSourceByUriDigestMutex.RLock()
 	defer fake.getSourceByUriDigestMutex.RUnlock()
 	argsForCall := fake.getSourceByUriDigestArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeSourceRepository) GetSourceByUriDigestReturns(result1 *api.Source, result2 error) {
+func (fake *FakeSourceService) GetSourceByUriDigestReturns(result1 *api.Source, result2 error) {
 	fake.getSourceByUriDigestMutex.Lock()
 	defer fake.getSourceByUriDigestMutex.Unlock()
 	fake.GetSourceByUriDigestStub = nil
@@ -202,7 +201,7 @@ func (fake *FakeSourceRepository) GetSourceByUriDigestReturns(result1 *api.Sourc
 	}{result1, result2}
 }
 
-func (fake *FakeSourceRepository) GetSourceByUriDigestReturnsOnCall(i int, result1 *api.Source, result2 error) {
+func (fake *FakeSourceService) GetSourceByUriDigestReturnsOnCall(i int, result1 *api.Source, result2 error) {
 	fake.getSourceByUriDigestMutex.Lock()
 	defer fake.getSourceByUriDigestMutex.Unlock()
 	fake.GetSourceByUriDigestStub = nil
@@ -218,7 +217,7 @@ func (fake *FakeSourceRepository) GetSourceByUriDigestReturnsOnCall(i int, resul
 	}{result1, result2}
 }
 
-func (fake *FakeSourceRepository) GetSources(arg1 context.Context) ([]api.Source, error) {
+func (fake *FakeSourceService) GetSources(arg1 context.Context) ([]api.Source, error) {
 	fake.getSourcesMutex.Lock()
 	ret, specificReturn := fake.getSourcesReturnsOnCall[len(fake.getSourcesArgsForCall)]
 	fake.getSourcesArgsForCall = append(fake.getSourcesArgsForCall, struct {
@@ -237,26 +236,26 @@ func (fake *FakeSourceRepository) GetSources(arg1 context.Context) ([]api.Source
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeSourceRepository) GetSourcesCallCount() int {
+func (fake *FakeSourceService) GetSourcesCallCount() int {
 	fake.getSourcesMutex.RLock()
 	defer fake.getSourcesMutex.RUnlock()
 	return len(fake.getSourcesArgsForCall)
 }
 
-func (fake *FakeSourceRepository) GetSourcesCalls(stub func(context.Context) ([]api.Source, error)) {
+func (fake *FakeSourceService) GetSourcesCalls(stub func(context.Context) ([]api.Source, error)) {
 	fake.getSourcesMutex.Lock()
 	defer fake.getSourcesMutex.Unlock()
 	fake.GetSourcesStub = stub
 }
 
-func (fake *FakeSourceRepository) GetSourcesArgsForCall(i int) context.Context {
+func (fake *FakeSourceService) GetSourcesArgsForCall(i int) context.Context {
 	fake.getSourcesMutex.RLock()
 	defer fake.getSourcesMutex.RUnlock()
 	argsForCall := fake.getSourcesArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeSourceRepository) GetSourcesReturns(result1 []api.Source, result2 error) {
+func (fake *FakeSourceService) GetSourcesReturns(result1 []api.Source, result2 error) {
 	fake.getSourcesMutex.Lock()
 	defer fake.getSourcesMutex.Unlock()
 	fake.GetSourcesStub = nil
@@ -266,7 +265,7 @@ func (fake *FakeSourceRepository) GetSourcesReturns(result1 []api.Source, result
 	}{result1, result2}
 }
 
-func (fake *FakeSourceRepository) GetSourcesReturnsOnCall(i int, result1 []api.Source, result2 error) {
+func (fake *FakeSourceService) GetSourcesReturnsOnCall(i int, result1 []api.Source, result2 error) {
 	fake.getSourcesMutex.Lock()
 	defer fake.getSourcesMutex.Unlock()
 	fake.GetSourcesStub = nil
@@ -282,7 +281,7 @@ func (fake *FakeSourceRepository) GetSourcesReturnsOnCall(i int, result1 []api.S
 	}{result1, result2}
 }
 
-func (fake *FakeSourceRepository) PatchSourceByUriDigest(arg1 context.Context, arg2 *api.SourcePatchInput, arg3 string) error {
+func (fake *FakeSourceService) PatchSourceByUriDigest(arg1 context.Context, arg2 *api.SourcePatchInput, arg3 string) error {
 	fake.patchSourceByUriDigestMutex.Lock()
 	ret, specificReturn := fake.patchSourceByUriDigestReturnsOnCall[len(fake.patchSourceByUriDigestArgsForCall)]
 	fake.patchSourceByUriDigestArgsForCall = append(fake.patchSourceByUriDigestArgsForCall, struct {
@@ -303,26 +302,26 @@ func (fake *FakeSourceRepository) PatchSourceByUriDigest(arg1 context.Context, a
 	return fakeReturns.result1
 }
 
-func (fake *FakeSourceRepository) PatchSourceByUriDigestCallCount() int {
+func (fake *FakeSourceService) PatchSourceByUriDigestCallCount() int {
 	fake.patchSourceByUriDigestMutex.RLock()
 	defer fake.patchSourceByUriDigestMutex.RUnlock()
 	return len(fake.patchSourceByUriDigestArgsForCall)
 }
 
-func (fake *FakeSourceRepository) PatchSourceByUriDigestCalls(stub func(context.Context, *api.SourcePatchInput, string) error) {
+func (fake *FakeSourceService) PatchSourceByUriDigestCalls(stub func(context.Context, *api.SourcePatchInput, string) error) {
 	fake.patchSourceByUriDigestMutex.Lock()
 	defer fake.patchSourceByUriDigestMutex.Unlock()
 	fake.PatchSourceByUriDigestStub = stub
 }
 
-func (fake *FakeSourceRepository) PatchSourceByUriDigestArgsForCall(i int) (context.Context, *api.SourcePatchInput, string) {
+func (fake *FakeSourceService) PatchSourceByUriDigestArgsForCall(i int) (context.Context, *api.SourcePatchInput, string) {
 	fake.patchSourceByUriDigestMutex.RLock()
 	defer fake.patchSourceByUriDigestMutex.RUnlock()
 	argsForCall := fake.patchSourceByUriDigestArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeSourceRepository) PatchSourceByUriDigestReturns(result1 error) {
+func (fake *FakeSourceService) PatchSourceByUriDigestReturns(result1 error) {
 	fake.patchSourceByUriDigestMutex.Lock()
 	defer fake.patchSourceByUriDigestMutex.Unlock()
 	fake.PatchSourceByUriDigestStub = nil
@@ -331,7 +330,7 @@ func (fake *FakeSourceRepository) PatchSourceByUriDigestReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeSourceRepository) PatchSourceByUriDigestReturnsOnCall(i int, result1 error) {
+func (fake *FakeSourceService) PatchSourceByUriDigestReturnsOnCall(i int, result1 error) {
 	fake.patchSourceByUriDigestMutex.Lock()
 	defer fake.patchSourceByUriDigestMutex.Unlock()
 	fake.PatchSourceByUriDigestStub = nil
@@ -345,7 +344,7 @@ func (fake *FakeSourceRepository) PatchSourceByUriDigestReturnsOnCall(i int, res
 	}{result1}
 }
 
-func (fake *FakeSourceRepository) PostSource(arg1 context.Context, arg2 *api.SourceInput) (string, error) {
+func (fake *FakeSourceService) PostSource(arg1 context.Context, arg2 *api.SourceInput) (string, error) {
 	fake.postSourceMutex.Lock()
 	ret, specificReturn := fake.postSourceReturnsOnCall[len(fake.postSourceArgsForCall)]
 	fake.postSourceArgsForCall = append(fake.postSourceArgsForCall, struct {
@@ -365,26 +364,26 @@ func (fake *FakeSourceRepository) PostSource(arg1 context.Context, arg2 *api.Sou
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeSourceRepository) PostSourceCallCount() int {
+func (fake *FakeSourceService) PostSourceCallCount() int {
 	fake.postSourceMutex.RLock()
 	defer fake.postSourceMutex.RUnlock()
 	return len(fake.postSourceArgsForCall)
 }
 
-func (fake *FakeSourceRepository) PostSourceCalls(stub func(context.Context, *api.SourceInput) (string, error)) {
+func (fake *FakeSourceService) PostSourceCalls(stub func(context.Context, *api.SourceInput) (string, error)) {
 	fake.postSourceMutex.Lock()
 	defer fake.postSourceMutex.Unlock()
 	fake.PostSourceStub = stub
 }
 
-func (fake *FakeSourceRepository) PostSourceArgsForCall(i int) (context.Context, *api.SourceInput) {
+func (fake *FakeSourceService) PostSourceArgsForCall(i int) (context.Context, *api.SourceInput) {
 	fake.postSourceMutex.RLock()
 	defer fake.postSourceMutex.RUnlock()
 	argsForCall := fake.postSourceArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeSourceRepository) PostSourceReturns(result1 string, result2 error) {
+func (fake *FakeSourceService) PostSourceReturns(result1 string, result2 error) {
 	fake.postSourceMutex.Lock()
 	defer fake.postSourceMutex.Unlock()
 	fake.PostSourceStub = nil
@@ -394,7 +393,7 @@ func (fake *FakeSourceRepository) PostSourceReturns(result1 string, result2 erro
 	}{result1, result2}
 }
 
-func (fake *FakeSourceRepository) PostSourceReturnsOnCall(i int, result1 string, result2 error) {
+func (fake *FakeSourceService) PostSourceReturnsOnCall(i int, result1 string, result2 error) {
 	fake.postSourceMutex.Lock()
 	defer fake.postSourceMutex.Unlock()
 	fake.PostSourceStub = nil
@@ -410,19 +409,18 @@ func (fake *FakeSourceRepository) PostSourceReturnsOnCall(i int, result1 string,
 	}{result1, result2}
 }
 
-func (fake *FakeSourceRepository) UpdateAllScores(arg1 context.Context, arg2 *[]api.Source) error {
+func (fake *FakeSourceService) UpdateAllScores(arg1 context.Context) error {
 	fake.updateAllScoresMutex.Lock()
 	ret, specificReturn := fake.updateAllScoresReturnsOnCall[len(fake.updateAllScoresArgsForCall)]
 	fake.updateAllScoresArgsForCall = append(fake.updateAllScoresArgsForCall, struct {
 		arg1 context.Context
-		arg2 *[]api.Source
-	}{arg1, arg2})
+	}{arg1})
 	stub := fake.UpdateAllScoresStub
 	fakeReturns := fake.updateAllScoresReturns
-	fake.recordInvocation("UpdateAllScores", []interface{}{arg1, arg2})
+	fake.recordInvocation("UpdateAllScores", []interface{}{arg1})
 	fake.updateAllScoresMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -430,26 +428,26 @@ func (fake *FakeSourceRepository) UpdateAllScores(arg1 context.Context, arg2 *[]
 	return fakeReturns.result1
 }
 
-func (fake *FakeSourceRepository) UpdateAllScoresCallCount() int {
+func (fake *FakeSourceService) UpdateAllScoresCallCount() int {
 	fake.updateAllScoresMutex.RLock()
 	defer fake.updateAllScoresMutex.RUnlock()
 	return len(fake.updateAllScoresArgsForCall)
 }
 
-func (fake *FakeSourceRepository) UpdateAllScoresCalls(stub func(context.Context, *[]api.Source) error) {
+func (fake *FakeSourceService) UpdateAllScoresCalls(stub func(context.Context) error) {
 	fake.updateAllScoresMutex.Lock()
 	defer fake.updateAllScoresMutex.Unlock()
 	fake.UpdateAllScoresStub = stub
 }
 
-func (fake *FakeSourceRepository) UpdateAllScoresArgsForCall(i int) (context.Context, *[]api.Source) {
+func (fake *FakeSourceService) UpdateAllScoresArgsForCall(i int) context.Context {
 	fake.updateAllScoresMutex.RLock()
 	defer fake.updateAllScoresMutex.RUnlock()
 	argsForCall := fake.updateAllScoresArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1
 }
 
-func (fake *FakeSourceRepository) UpdateAllScoresReturns(result1 error) {
+func (fake *FakeSourceService) UpdateAllScoresReturns(result1 error) {
 	fake.updateAllScoresMutex.Lock()
 	defer fake.updateAllScoresMutex.Unlock()
 	fake.UpdateAllScoresStub = nil
@@ -458,7 +456,7 @@ func (fake *FakeSourceRepository) UpdateAllScoresReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeSourceRepository) UpdateAllScoresReturnsOnCall(i int, result1 error) {
+func (fake *FakeSourceService) UpdateAllScoresReturnsOnCall(i int, result1 error) {
 	fake.updateAllScoresMutex.Lock()
 	defer fake.updateAllScoresMutex.Unlock()
 	fake.UpdateAllScoresStub = nil
@@ -472,7 +470,7 @@ func (fake *FakeSourceRepository) UpdateAllScoresReturnsOnCall(i int, result1 er
 	}{result1}
 }
 
-func (fake *FakeSourceRepository) Invocations() map[string][][]interface{} {
+func (fake *FakeSourceService) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
@@ -482,7 +480,7 @@ func (fake *FakeSourceRepository) Invocations() map[string][][]interface{} {
 	return copiedInvocations
 }
 
-func (fake *FakeSourceRepository) recordInvocation(key string, args []interface{}) {
+func (fake *FakeSourceService) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
@@ -494,4 +492,4 @@ func (fake *FakeSourceRepository) recordInvocation(key string, args []interface{
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ source.SourceRepository = new(FakeSourceRepository)
+var _ source.SourceService = new(FakeSourceService)

--- a/pkg/handlers/source.go
+++ b/pkg/handlers/source.go
@@ -3,10 +3,13 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"source-score/pkg/api"
 	"source-score/pkg/apperrors"
 	"source-score/pkg/domain/source"
+	"sync/atomic"
 
 	"github.com/gin-gonic/gin"
 )
@@ -14,6 +17,10 @@ import (
 type SourceHandler struct {
 	sourceSvc source.SourceService
 }
+
+var (
+	scoreJobRunning atomic.Bool
+)
 
 func NewSourceHandler(ctx context.Context, sourceSvc source.SourceService) *SourceHandler {
 	return &SourceHandler{
@@ -149,4 +156,20 @@ func (sh *SourceHandler) PatchSourceByUriDigest(ctx *gin.Context, uriDigest stri
 	}
 
 	ctx.Status(http.StatusNoContent)
+}
+
+func (sh *SourceHandler) UpdateAllScores(ctx *gin.Context) {
+	if scoreJobRunning.CompareAndSwap(false, true) {
+		go func(c *gin.Context) {
+			defer scoreJobRunning.Store(false)
+			if err := sh.sourceSvc.UpdateAllScores(c); err != nil {
+				slog.Error(fmt.Sprintf("source score update job failed with error: %v", err))
+			}
+		}(ctx.Copy())
+
+		ctx.Status(http.StatusAccepted)
+		return
+	}
+
+	ctx.Status(http.StatusConflict)
 }

--- a/pkg/http/router.go
+++ b/pkg/http/router.go
@@ -106,3 +106,6 @@ func (r *router) GetProofs(ctx *gin.Context) {
 func (r *router) PatchProof(ctx *gin.Context, uriDigest string) {
 	r.proofHandler.PatchProofByUriDigest(ctx, uriDigest)
 }
+
+func (r *router) UpdateScores(ctx *gin.Context) {
+}

--- a/pkg/http/router.go
+++ b/pkg/http/router.go
@@ -108,4 +108,5 @@ func (r *router) PatchProof(ctx *gin.Context, uriDigest string) {
 }
 
 func (r *router) UpdateAllScores(ctx *gin.Context) {
+	r.srcHandler.UpdateAllScores(ctx)
 }

--- a/pkg/http/router.go
+++ b/pkg/http/router.go
@@ -107,5 +107,5 @@ func (r *router) PatchProof(ctx *gin.Context, uriDigest string) {
 	r.proofHandler.PatchProofByUriDigest(ctx, uriDigest)
 }
 
-func (r *router) UpdateScores(ctx *gin.Context) {
+func (r *router) UpdateAllScores(ctx *gin.Context) {
 }


### PR DESCRIPTION
Fixes: #73 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `POST /api/v1/sources/scores` to trigger async source score recalculation from checked claims and bulk-persist the results as floats in the 0–1 range. Bulk claim verification now lives at `POST /api/v1/claims/verify` (addresses #73).

- **New Features**
  - New API `POST /api/v1/sources/scores` returns 202 (accepted) or 409 (in progress); single job enforced with an atomic guard.
  - Source service adds `UpdateAllScores` to compute per-source scores (valid/total) from checked claims via `ClaimRepository.GetCheckedClaimsBySources`, and persists with `SourceRepository.UpdateAllScores` (uses `CAST(? AS FLOAT)` in SQL).
  - Claim repo method renamed to `VerifyAllClaims`; new route `POST /api/v1/claims/verify`.
  - Router/OpenAPI updated; app wires source service with the claim repo.

- **Migration**
  - DB: `sources.score` SMALLINT [0–100] -> FLOAT [0–1] with updated CHECK and default 0.
  - Migrate existing rows by dividing stored scores by 100.
  - Update clients to accept and display scores in the 0–1 range.
  - Update clients to call `POST /api/v1/claims/verify` for bulk verification.

<sup>Written for commit ceb849c43e3b6143d27c76c50d0146d806647045. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

