### PR TITLE
feat: adds claims verification job trigger endpoint

### DIFF
--- a/acceptance/claim_test.go
+++ b/acceptance/claim_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"source-score/pkg/api"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -226,37 +227,38 @@ var _ = Describe("Claim model tests", func() {
 			})
 		})
 
-		When("POST request is sent to verify a claim", func() {
-			It("should verify the claim and subsequent GET returns updated checked and validity fields", func() {
-				claimUrl, err := url.JoinPath(endpoint, claim2Digest)
-				Expect(err).To(BeNil())
+		// TODO: uncomment when single claim verification is enabled
+		// When("POST request is sent to verify a claim", func() {
+		// 	It("should verify the claim and subsequent GET returns updated checked and validity fields", func() {
+		// 		claimUrl, err := url.JoinPath(endpoint, claim2Digest)
+		// 		Expect(err).To(BeNil())
 
-				// verify claim with validity true
-				validity := true
-				verifyBody := api.ClaimVerification{
-					Validity: &validity,
-				}
-				body, err := json.Marshal(verifyBody)
-				Expect(err).To(BeNil())
+		// 		// verify claim with validity true
+		// 		validity := true
+		// 		verifyBody := api.ClaimVerification{
+		// 			Validity: &validity,
+		// 		}
+		// 		body, err := json.Marshal(verifyBody)
+		// 		Expect(err).To(BeNil())
 
-				resp, err := http.Post(claimUrl, "application/json", bytes.NewBuffer(body))
-				Expect(err).To(BeNil())
-				defer resp.Body.Close()
-				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+		// 		resp, err := http.Post(claimUrl, "application/json", bytes.NewBuffer(body))
+		// 		Expect(err).To(BeNil())
+		// 		defer resp.Body.Close()
+		// 		Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
-				// verify the claim was updated
-				resp, err = http.Get(claimUrl)
-				Expect(err).To(BeNil())
-				defer resp.Body.Close()
-				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		// 		// verify the claim was updated
+		// 		resp, err = http.Get(claimUrl)
+		// 		Expect(err).To(BeNil())
+		// 		defer resp.Body.Close()
+		// 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				var c api.Claim
-				err = json.NewDecoder(resp.Body).Decode(&c)
-				Expect(err).To(BeNil())
-				Expect(c.Checked).To(BeTrue())
-				Expect(c.Validity).To(BeTrue())
-			})
-		})
+		// 		var c api.Claim
+		// 		err = json.NewDecoder(resp.Body).Decode(&c)
+		// 		Expect(err).To(BeNil())
+		// 		Expect(c.Checked).To(BeTrue())
+		// 		Expect(c.Validity).To(BeTrue())
+		// 	})
+		// })
 
 		When("DELETE request is sent to delete the created claim", func() {
 			It("should delete the created claim and subsequent GET returns 404", func() {
@@ -282,7 +284,13 @@ var _ = Describe("Claim model tests", func() {
 		When("Verifying all claims based on their proofs", func() {
 			It("Should verify claims with validity based on proof counts", func() {
 				// Create a new source
-				srcBody, err := json.Marshal(sourceInput3)
+				srcInput := api.SourceInput{
+					Name:    "Test Source for Verify All",
+					Summary: "sample summary",
+					Tags:    "tag45",
+					Uri:     "https://test-source-verify-all",
+				}
+				srcBody, err := json.Marshal(srcInput)
 				Expect(err).To(BeNil())
 
 				resp, err := http.Post(srcEndpoint, "application/json", bytes.NewBuffer(srcBody))
@@ -403,35 +411,37 @@ var _ = Describe("Claim model tests", func() {
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
 
-				// Assert claim 1 has validity=true (3 supporting > 1 refuting)
-				claim1Url, err := url.JoinPath(endpoint, testClaim1Digest)
-				Expect(err).To(BeNil())
+				Eventually(func(g Gomega) {
+					// Assert claim 1 has validity=true (3 supporting > 1 refuting)
+					claim1Url, err := url.JoinPath(endpoint, testClaim1Digest)
+					g.Expect(err).To(BeNil())
 
-				resp, err = http.Get(claim1Url)
-				Expect(err).To(BeNil())
-				defer resp.Body.Close()
-				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+					resp, err = http.Get(claim1Url)
+					g.Expect(err).To(BeNil())
+					g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				var c1 api.Claim
-				err = json.NewDecoder(resp.Body).Decode(&c1)
-				Expect(err).To(BeNil())
-				Expect(c1.Checked).To(BeTrue())
-				Expect(c1.Validity).To(BeTrue())
+					var c1 api.Claim
+					err = json.NewDecoder(resp.Body).Decode(&c1)
+					g.Expect(err).To(BeNil())
+					g.Expect(c1.Checked).To(BeTrue())
+					g.Expect(c1.Validity).To(BeTrue())
+					resp.Body.Close()
 
-				// Assert claim 2 has validity=false (1 supporting < 2 refuting)
-				claim2Url, err := url.JoinPath(endpoint, testClaim2Digest)
-				Expect(err).To(BeNil())
+					// Assert claim 2 has validity=false (1 supporting < 2 refuting)
+					claim2Url, err := url.JoinPath(endpoint, testClaim2Digest)
+					g.Expect(err).To(BeNil())
 
-				resp, err = http.Get(claim2Url)
-				Expect(err).To(BeNil())
-				defer resp.Body.Close()
-				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+					resp, err = http.Get(claim2Url)
+					g.Expect(err).To(BeNil())
+					g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				var c2 api.Claim
-				err = json.NewDecoder(resp.Body).Decode(&c2)
-				Expect(err).To(BeNil())
-				Expect(c2.Checked).To(BeTrue())
-				Expect(c2.Validity).To(BeFalse())
+					var c2 api.Claim
+					err = json.NewDecoder(resp.Body).Decode(&c2)
+					g.Expect(err).To(BeNil())
+					g.Expect(c2.Checked).To(BeTrue())
+					g.Expect(c2.Validity).To(BeFalse())
+					resp.Body.Close()
+				}, 10*time.Second, 1*time.Second).Should(Succeed())
 			})
 		})
 	})
@@ -605,198 +615,52 @@ var _ = Describe("Claim model tests", func() {
 			})
 		})
 
-		When("POST request to verify claim without Validity field is sent", func() {
-			It("should return 400 with validation error mentioning validity", func() {
-				claimUrl, err := url.JoinPath(endpoint, claim2Digest)
-				Expect(err).To(BeNil())
+		// TODO: uncomment when single claim verification is enabled
+		// When("POST request to verify claim without Validity field is sent", func() {
+		// 	It("should return 400 with validation error mentioning validity", func() {
+		// 		claimUrl, err := url.JoinPath(endpoint, claim2Digest)
+		// 		Expect(err).To(BeNil())
 
-				verifyBody := api.ClaimVerification{}
-				body, err := json.Marshal(verifyBody)
-				Expect(err).To(BeNil())
+		// 		verifyBody := api.ClaimVerification{}
+		// 		body, err := json.Marshal(verifyBody)
+		// 		Expect(err).To(BeNil())
 
-				resp, err := http.Post(claimUrl, "application/json", bytes.NewBuffer(body))
-				Expect(err).To(BeNil())
-				defer resp.Body.Close()
-				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		// 		resp, err := http.Post(claimUrl, "application/json", bytes.NewBuffer(body))
+		// 		Expect(err).To(BeNil())
+		// 		defer resp.Body.Close()
+		// 		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 
-				var errResp map[string]string
-				err = json.NewDecoder(resp.Body).Decode(&errResp)
-				Expect(err).To(BeNil())
-				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("validity"))
-				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("required"))
-			})
-		})
+		// 		var errResp map[string]string
+		// 		err = json.NewDecoder(resp.Body).Decode(&errResp)
+		// 		Expect(err).To(BeNil())
+		// 		Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("validity"))
+		// 		Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("required"))
+		// 	})
+		// })
 
-		When("POST request to verify a non-existent claim is sent", func() {
-			It("should return 404 with claim not found error", func() {
-				claimUrl, err := url.JoinPath(endpoint, "doesnotexist")
-				Expect(err).To(BeNil())
+		// TODO: uncomment when single claim verification is enabled
+		// When("POST request to verify a non-existent claim is sent", func() {
+		// 	It("should return 404 with claim not found error", func() {
+		// 		claimUrl, err := url.JoinPath(endpoint, "doesnotexist")
+		// 		Expect(err).To(BeNil())
 
-				validity := true
-				verifyBody := api.ClaimVerification{
-					Validity: &validity,
-				}
-				body, err := json.Marshal(verifyBody)
-				Expect(err).To(BeNil())
+		// 		validity := true
+		// 		verifyBody := api.ClaimVerification{
+		// 			Validity: &validity,
+		// 		}
+		// 		body, err := json.Marshal(verifyBody)
+		// 		Expect(err).To(BeNil())
 
-				resp, err := http.Post(claimUrl, "application/json", bytes.NewBuffer(body))
-				Expect(err).To(BeNil())
-				defer resp.Body.Close()
-				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		// 		resp, err := http.Post(claimUrl, "application/json", bytes.NewBuffer(body))
+		// 		Expect(err).To(BeNil())
+		// 		defer resp.Body.Close()
+		// 		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 
-				var errResp map[string]string
-				err = json.NewDecoder(resp.Body).Decode(&errResp)
-				Expect(err).To(BeNil())
-				Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("claim not found"))
-			})
-		})
-
-		When("POST request is sent to verify all claims based on proofs", func() {
-			It("should verify claims with validity based on proof counts", func() {
-				srcBody, err := json.Marshal(sourceInput3)
-				Expect(err).To(BeNil())
-
-				resp, err := http.Post(srcEndpoint, "application/json", bytes.NewBuffer(srcBody))
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
-
-				var srcResp api.CreateSourceResponse
-				err = json.NewDecoder(resp.Body).Decode(&srcResp)
-				Expect(err).To(BeNil())
-				resp.Body.Close()
-
-				claim1Input := api.ClaimInput{
-					SourceUriDigest: srcResp.UriDigest,
-					Summary:         "Test claim 1 for verify all",
-					Title:           "Test Claim 1",
-					Uri:             "https://test-claim-verify-all-1",
-				}
-				body1, err := json.Marshal(claim1Input)
-				Expect(err).To(BeNil())
-
-				resp, err = http.Post(endpoint, "application/json", bytes.NewBuffer(body1))
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
-
-				var respBody map[string]string
-				err = json.NewDecoder(resp.Body).Decode(&respBody)
-				Expect(err).To(BeNil())
-				resp.Body.Close()
-				testClaim1Digest := respBody["uriDigest"]
-
-				claim2Input := api.ClaimInput{
-					SourceUriDigest: srcResp.UriDigest,
-					Summary:         "Test claim 2 for verify all",
-					Title:           "Test Claim 2",
-					Uri:             "https://test-claim-verify-all-2",
-				}
-				body2, err := json.Marshal(claim2Input)
-				Expect(err).To(BeNil())
-
-				resp, err = http.Post(endpoint, "application/json", bytes.NewBuffer(body2))
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
-
-				err = json.NewDecoder(resp.Body).Decode(&respBody)
-				Expect(err).To(BeNil())
-				resp.Body.Close()
-				testClaim2Digest := respBody["uriDigest"]
-
-				proofEndpoint, err := url.JoinPath(baseUrl, "/api/v1/proof")
-				Expect(err).To(BeNil())
-
-				for i := 0; i < 3; i++ {
-					supports := true
-					proofInput := api.ProofInput{
-						ClaimUriDigest: testClaim1Digest,
-						ReviewedBy:     "ReviewerA",
-						SupportsClaim:  &supports,
-						Uri:            fmt.Sprintf("https://proof-claim1-support-%d", i),
-					}
-					proofBody, _ := json.Marshal(proofInput)
-					resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
-					Expect(err).To(BeNil())
-					Expect(resp.StatusCode).To(Equal(http.StatusCreated))
-					resp.Body.Close()
-				}
-
-				supports := false
-				proofInput := api.ProofInput{
-					ClaimUriDigest: testClaim1Digest,
-					ReviewedBy:     "ReviewerB",
-					SupportsClaim:  &supports,
-					Uri:            "https://proof-claim1-refute",
-				}
-				proofBody, _ := json.Marshal(proofInput)
-				resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
-				resp.Body.Close()
-
-				supports = true
-				proofInput = api.ProofInput{
-					ClaimUriDigest: testClaim2Digest,
-					ReviewedBy:     "ReviewerC",
-					SupportsClaim:  &supports,
-					Uri:            "https://proof-claim2-support",
-				}
-				proofBody, _ = json.Marshal(proofInput)
-				resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
-				Expect(err).To(BeNil())
-				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
-				resp.Body.Close()
-
-				for i := 0; i < 2; i++ {
-					supports := false
-					proofInput := api.ProofInput{
-						ClaimUriDigest: testClaim2Digest,
-						ReviewedBy:     "ReviewerD",
-						SupportsClaim:  &supports,
-						Uri:            fmt.Sprintf("https://proof-claim2-refute-%d", i),
-					}
-					proofBody, _ := json.Marshal(proofInput)
-					resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
-					Expect(err).To(BeNil())
-					Expect(resp.StatusCode).To(Equal(http.StatusCreated))
-					resp.Body.Close()
-				}
-
-				verifyAllUrl, err := url.JoinPath(baseUrl, "/api/v1/claims")
-				Expect(err).To(BeNil())
-
-				resp, err = http.Post(verifyAllUrl, "application/json", nil)
-				Expect(err).To(BeNil())
-				defer resp.Body.Close()
-				Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
-
-				claim1Url, err := url.JoinPath(endpoint, testClaim1Digest)
-				Expect(err).To(BeNil())
-
-				resp, err = http.Get(claim1Url)
-				Expect(err).To(BeNil())
-				defer resp.Body.Close()
-				Expect(resp.StatusCode).To(Equal(http.StatusOK))
-
-				var c1 api.Claim
-				err = json.NewDecoder(resp.Body).Decode(&c1)
-				Expect(err).To(BeNil())
-				Expect(c1.Checked).To(BeTrue())
-				Expect(c1.Validity).To(BeTrue())
-
-				claim2Url, err := url.JoinPath(endpoint, testClaim2Digest)
-				Expect(err).To(BeNil())
-
-				resp, err = http.Get(claim2Url)
-				Expect(err).To(BeNil())
-				defer resp.Body.Close()
-				Expect(resp.StatusCode).To(Equal(http.StatusOK))
-
-				var c2 api.Claim
-				err = json.NewDecoder(resp.Body).Decode(&c2)
-				Expect(err).To(BeNil())
-				Expect(c2.Checked).To(BeTrue())
-				Expect(c2.Validity).To(BeFalse())
-			})
-		})
+		// 		var errResp map[string]string
+		// 		err = json.NewDecoder(resp.Body).Decode(&errResp)
+		// 		Expect(err).To(BeNil())
+		// 		Expect(strings.ToLower(errResp["error"])).To(ContainSubstring("claim not found"))
+		// 	})
+		// })
 	})
 })

--- a/acceptance/claim_test.go
+++ b/acceptance/claim_test.go
@@ -3,6 +3,7 @@ package acceptance_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"source-score/pkg/api"
@@ -277,6 +278,162 @@ var _ = Describe("Claim model tests", func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 			})
 		})
+
+		When("Verifying all claims based on their proofs", func() {
+			It("Should verify claims with validity based on proof counts", func() {
+				// Create a new source
+				srcBody, err := json.Marshal(sourceInput3)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(srcEndpoint, "application/json", bytes.NewBuffer(srcBody))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
+
+				var srcResp api.CreateSourceResponse
+				err = json.NewDecoder(resp.Body).Decode(&srcResp)
+				Expect(err).To(BeNil())
+				resp.Body.Close()
+
+				// Create claim 1
+				claim1Input := api.ClaimInput{
+					SourceUriDigest: srcResp.UriDigest,
+					Summary:         "Test claim 1 for verify all",
+					Title:           "Test Claim 1",
+					Uri:             "https://test-claim-verify-1",
+				}
+				body1, err := json.Marshal(claim1Input)
+				Expect(err).To(BeNil())
+
+				resp, err = http.Post(endpoint, "application/json", bytes.NewBuffer(body1))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
+
+				var respBody map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&respBody)
+				Expect(err).To(BeNil())
+				resp.Body.Close()
+				testClaim1Digest := respBody["uriDigest"]
+
+				// Create claim 2
+				claim2Input := api.ClaimInput{
+					SourceUriDigest: srcResp.UriDigest,
+					Summary:         "Test claim 2 for verify all",
+					Title:           "Test Claim 2",
+					Uri:             "https://test-claim-verify-2",
+				}
+				body2, err := json.Marshal(claim2Input)
+				Expect(err).To(BeNil())
+
+				resp, err = http.Post(endpoint, "application/json", bytes.NewBuffer(body2))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
+
+				err = json.NewDecoder(resp.Body).Decode(&respBody)
+				Expect(err).To(BeNil())
+				resp.Body.Close()
+				testClaim2Digest := respBody["uriDigest"]
+
+				// Create proofs for claim 1 (3 supporting, 1 refuting) -> validity = true
+				proofEndpoint, err := url.JoinPath(baseUrl, "/api/v1/proof")
+				Expect(err).To(BeNil())
+
+				for i := range 3 {
+					supports := true
+					proofInput := api.ProofInput{
+						ClaimUriDigest: testClaim1Digest,
+						ReviewedBy:     "ReviewerA",
+						SupportsClaim:  &supports,
+						Uri:            fmt.Sprintf("https://proof-claim1-support-%d", i),
+					}
+					proofBody, _ := json.Marshal(proofInput)
+					resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+					Expect(err).To(BeNil())
+					Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+					resp.Body.Close()
+				}
+
+				supports := false
+				proofInput := api.ProofInput{
+					ClaimUriDigest: testClaim1Digest,
+					ReviewedBy:     "ReviewerB",
+					SupportsClaim:  &supports,
+					Uri:            "https://proof-claim1-refute",
+				}
+				proofBody, _ := json.Marshal(proofInput)
+				resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+				resp.Body.Close()
+
+				// Create proofs for claim 2 (1 supporting, 2 refuting) -> validity = false
+				supports = true
+				proofInput = api.ProofInput{
+					ClaimUriDigest: testClaim2Digest,
+					ReviewedBy:     "ReviewerC",
+					SupportsClaim:  &supports,
+					Uri:            "https://proof-claim2-support",
+				}
+				proofBody, _ = json.Marshal(proofInput)
+				resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+				resp.Body.Close()
+
+				for i := range 2 {
+					supports := false
+					proofInput := api.ProofInput{
+						ClaimUriDigest: testClaim2Digest,
+						ReviewedBy:     "ReviewerD",
+						SupportsClaim:  &supports,
+						Uri:            fmt.Sprintf("https://proof-claim2-refute-%d", i),
+					}
+					proofBody, _ := json.Marshal(proofInput)
+					resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+					Expect(err).To(BeNil())
+					Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+					resp.Body.Close()
+				}
+
+				// Hit the verify all claims endpoint
+				verifyAllUrl, err := url.JoinPath(baseUrl, "/api/v1/claims")
+				Expect(err).To(BeNil())
+
+				resp, err = http.Post(verifyAllUrl, "application/json", nil)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+
+				// Assert claim 1 has validity=true (3 supporting > 1 refuting)
+				claim1Url, err := url.JoinPath(endpoint, testClaim1Digest)
+				Expect(err).To(BeNil())
+
+				resp, err = http.Get(claim1Url)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				var c1 api.Claim
+				err = json.NewDecoder(resp.Body).Decode(&c1)
+				Expect(err).To(BeNil())
+				Expect(c1.Checked).To(BeTrue())
+				Expect(c1.Validity).To(BeTrue())
+
+				// Assert claim 2 has validity=false (1 supporting < 2 refuting)
+				claim2Url, err := url.JoinPath(endpoint, testClaim2Digest)
+				Expect(err).To(BeNil())
+
+				resp, err = http.Get(claim2Url)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				var c2 api.Claim
+				err = json.NewDecoder(resp.Body).Decode(&c2)
+				Expect(err).To(BeNil())
+				Expect(c2.Checked).To(BeTrue())
+				Expect(c2.Validity).To(BeFalse())
+			})
+		})
 	})
 
 	Context("Validation tests", func() {
@@ -453,8 +610,7 @@ var _ = Describe("Claim model tests", func() {
 				claimUrl, err := url.JoinPath(endpoint, claim2Digest)
 				Expect(err).To(BeNil())
 
-				verifyBody := api.ClaimVerification{
-				}
+				verifyBody := api.ClaimVerification{}
 				body, err := json.Marshal(verifyBody)
 				Expect(err).To(BeNil())
 
@@ -495,6 +651,152 @@ var _ = Describe("Claim model tests", func() {
 			})
 		})
 
-		
+		When("POST request is sent to verify all claims based on proofs", func() {
+			It("should verify claims with validity based on proof counts", func() {
+				srcBody, err := json.Marshal(sourceInput3)
+				Expect(err).To(BeNil())
+
+				resp, err := http.Post(srcEndpoint, "application/json", bytes.NewBuffer(srcBody))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
+
+				var srcResp api.CreateSourceResponse
+				err = json.NewDecoder(resp.Body).Decode(&srcResp)
+				Expect(err).To(BeNil())
+				resp.Body.Close()
+
+				claim1Input := api.ClaimInput{
+					SourceUriDigest: srcResp.UriDigest,
+					Summary:         "Test claim 1 for verify all",
+					Title:           "Test Claim 1",
+					Uri:             "https://test-claim-verify-all-1",
+				}
+				body1, err := json.Marshal(claim1Input)
+				Expect(err).To(BeNil())
+
+				resp, err = http.Post(endpoint, "application/json", bytes.NewBuffer(body1))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
+
+				var respBody map[string]string
+				err = json.NewDecoder(resp.Body).Decode(&respBody)
+				Expect(err).To(BeNil())
+				resp.Body.Close()
+				testClaim1Digest := respBody["uriDigest"]
+
+				claim2Input := api.ClaimInput{
+					SourceUriDigest: srcResp.UriDigest,
+					Summary:         "Test claim 2 for verify all",
+					Title:           "Test Claim 2",
+					Uri:             "https://test-claim-verify-all-2",
+				}
+				body2, err := json.Marshal(claim2Input)
+				Expect(err).To(BeNil())
+
+				resp, err = http.Post(endpoint, "application/json", bytes.NewBuffer(body2))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
+
+				err = json.NewDecoder(resp.Body).Decode(&respBody)
+				Expect(err).To(BeNil())
+				resp.Body.Close()
+				testClaim2Digest := respBody["uriDigest"]
+
+				proofEndpoint, err := url.JoinPath(baseUrl, "/api/v1/proof")
+				Expect(err).To(BeNil())
+
+				for i := 0; i < 3; i++ {
+					supports := true
+					proofInput := api.ProofInput{
+						ClaimUriDigest: testClaim1Digest,
+						ReviewedBy:     "ReviewerA",
+						SupportsClaim:  &supports,
+						Uri:            fmt.Sprintf("https://proof-claim1-support-%d", i),
+					}
+					proofBody, _ := json.Marshal(proofInput)
+					resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+					Expect(err).To(BeNil())
+					Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+					resp.Body.Close()
+				}
+
+				supports := false
+				proofInput := api.ProofInput{
+					ClaimUriDigest: testClaim1Digest,
+					ReviewedBy:     "ReviewerB",
+					SupportsClaim:  &supports,
+					Uri:            "https://proof-claim1-refute",
+				}
+				proofBody, _ := json.Marshal(proofInput)
+				resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+				resp.Body.Close()
+
+				supports = true
+				proofInput = api.ProofInput{
+					ClaimUriDigest: testClaim2Digest,
+					ReviewedBy:     "ReviewerC",
+					SupportsClaim:  &supports,
+					Uri:            "https://proof-claim2-support",
+				}
+				proofBody, _ = json.Marshal(proofInput)
+				resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+				resp.Body.Close()
+
+				for i := 0; i < 2; i++ {
+					supports := false
+					proofInput := api.ProofInput{
+						ClaimUriDigest: testClaim2Digest,
+						ReviewedBy:     "ReviewerD",
+						SupportsClaim:  &supports,
+						Uri:            fmt.Sprintf("https://proof-claim2-refute-%d", i),
+					}
+					proofBody, _ := json.Marshal(proofInput)
+					resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+					Expect(err).To(BeNil())
+					Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+					resp.Body.Close()
+				}
+
+				verifyAllUrl, err := url.JoinPath(baseUrl, "/api/v1/claims")
+				Expect(err).To(BeNil())
+
+				resp, err = http.Post(verifyAllUrl, "application/json", nil)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+
+				claim1Url, err := url.JoinPath(endpoint, testClaim1Digest)
+				Expect(err).To(BeNil())
+
+				resp, err = http.Get(claim1Url)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				var c1 api.Claim
+				err = json.NewDecoder(resp.Body).Decode(&c1)
+				Expect(err).To(BeNil())
+				Expect(c1.Checked).To(BeTrue())
+				Expect(c1.Validity).To(BeTrue())
+
+				claim2Url, err := url.JoinPath(endpoint, testClaim2Digest)
+				Expect(err).To(BeNil())
+
+				resp, err = http.Get(claim2Url)
+				Expect(err).To(BeNil())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				var c2 api.Claim
+				err = json.NewDecoder(resp.Body).Decode(&c2)
+				Expect(err).To(BeNil())
+				Expect(c2.Checked).To(BeTrue())
+				Expect(c2.Validity).To(BeFalse())
+			})
+		})
 	})
 })

--- a/api/source-score.yaml
+++ b/api/source-score.yaml
@@ -124,6 +124,16 @@ paths:
                 items:
                   $ref: '#/components/schemas/Claim'
 
+    post:
+      tags:
+      - claims
+      operationId: verifyClaims
+      responses:
+        202:
+          description: claims verification triggered
+        409:
+          description: claims verification in progress
+
   /api/v1/claim:
     post:
       tags:

--- a/api/source-score.yaml
+++ b/api/source-score.yaml
@@ -127,7 +127,7 @@ paths:
     post:
       tags:
       - claims
-      operationId: verifyClaims
+      operationId: verifyAllClaims
       responses:
         202:
           description: claims verification triggered

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -61,14 +61,14 @@ func main() {
 		api.Claim{},
 	)
 
-	srcRepo := source.NewSourceRepository(context.Background(), dbClient)
-	srcSvc := source.NewSourceService(context.Background(), srcRepo)
-
-	claimRepo := claim.NewClaimRepository(context.Background(), dbClient)
-	claimSvc := claim.NewClaimService(context.Background(), claimRepo)
-
 	proofRepo := proof.NewProofRepository(context.Background(), dbClient)
 	proofSvc := proof.NewProofService(context.Background(), proofRepo)
+
+	claimRepo := claim.NewClaimRepository(context.Background(), dbClient)
+	claimSvc := claim.NewClaimService(context.Background(), claimRepo, proofSvc)
+
+	srcRepo := source.NewSourceRepository(context.Background(), dbClient)
+	srcSvc := source.NewSourceService(context.Background(), srcRepo)
 
 	server := gin.Default()
 	api.RegisterHandlersWithOptions(

--- a/pkg/api/server.gen.go
+++ b/pkg/api/server.gen.go
@@ -140,6 +140,9 @@ type ServerInterface interface {
 	// (GET /api/v1/claims)
 	GetClaims(c *gin.Context)
 
+	// (POST /api/v1/claims)
+	VerifyAllClaims(c *gin.Context)
+
 	// (POST /api/v1/proof)
 	PostProof(c *gin.Context)
 
@@ -303,6 +306,19 @@ func (siw *ServerInterfaceWrapper) GetClaims(c *gin.Context) {
 	}
 
 	siw.Handler.GetClaims(c)
+}
+
+// VerifyAllClaims operation middleware
+func (siw *ServerInterfaceWrapper) VerifyAllClaims(c *gin.Context) {
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.VerifyAllClaims(c)
 }
 
 // PostProof operation middleware
@@ -547,6 +563,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.PATCH(options.BaseURL+"/api/v1/claim/:uriDigest", wrapper.PatchClaim)
 	router.POST(options.BaseURL+"/api/v1/claim/:uriDigest", wrapper.VerifyClaim)
 	router.GET(options.BaseURL+"/api/v1/claims", wrapper.GetClaims)
+	router.POST(options.BaseURL+"/api/v1/claims", wrapper.VerifyAllClaims)
 	router.POST(options.BaseURL+"/api/v1/proof", wrapper.PostProof)
 	router.DELETE(options.BaseURL+"/api/v1/proof/:uriDigest", wrapper.DeleteProof)
 	router.GET(options.BaseURL+"/api/v1/proof/:uriDigest", wrapper.GetProof)

--- a/pkg/domain/claim/claim_repository.go
+++ b/pkg/domain/claim/claim_repository.go
@@ -141,7 +141,7 @@ func (cr *claimRepository) VerifyClaims(ctx context.Context, updatedClaims []api
 	query.WriteString("UPDATE claims SET checked = true, validity = CASE uri_digest")
 
 	for _, claim := range updatedClaims {
-		query.WriteString(" WHEN ? THEN ?")
+		query.WriteString(" WHEN ? THEN CAST(? AS BOOLEAN)")
 		args = append(args, claim.UriDigest, claim.Validity)
 		claimDigests = append(claimDigests, claim.UriDigest)
 	}

--- a/pkg/domain/claim/claim_repository.go
+++ b/pkg/domain/claim/claim_repository.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"source-score/pkg/api"
 	"source-score/pkg/db/pgsql"
@@ -19,6 +20,7 @@ type ClaimRepository interface {
 	DeleteClaimByUriDigest(ctx context.Context, claim *api.Claim) error
 	PatchClaimByUriDigest(ctx context.Context, claimInput *api.ClaimPatchInput, uriDigest string) error
 	VerifyClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error
+	VerifyClaims(ctx context.Context, updatedClaims []api.Claim) error
 }
 
 type claimRepository struct {
@@ -130,4 +132,28 @@ func (cr *claimRepository) VerifyClaimByUriDigest(ctx context.Context, claimVeri
 	slog.InfoContext(ctx, fmt.Sprintf("%d rows affected\n", result.RowsAffected))
 
 	return result.Error
+}
+
+func (cr *claimRepository) VerifyClaims(ctx context.Context, updatedClaims []api.Claim) error {
+	var args []any
+	var query strings.Builder
+	claimDigests := []string{}
+	query.WriteString("UPDATE claims SET checked = true, validity = CASE uri_digest")
+
+	for _, claim := range updatedClaims {
+		query.WriteString(" WHEN ? THEN ?")
+		args = append(args, claim.UriDigest, claim.Validity)
+		claimDigests = append(claimDigests, claim.UriDigest)
+	}
+
+	query.WriteString(" END WHERE uri_digest IN ?")
+	args = append(args, claimDigests)
+
+	result := cr.client.DB.Exec(query.String(), args...)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	fmt.Printf("rows updated: %d\n", result.RowsAffected)
+	return nil
 }

--- a/pkg/domain/claim/claim_repository_test.go
+++ b/pkg/domain/claim/claim_repository_test.go
@@ -115,6 +115,84 @@ var _ = Describe("Claim repository layer unit tests", func() {
 				Expect(validated.Validity).To(BeTrue())
 			})
 		})
+
+		When("Verifying multiple claims at once", func() {
+			It("Should update checked and validity fields for all provided claims", func() {
+				// Create a new source for this test
+				newSource := api.Source{
+					Name:      "Test Source for VerifyClaims",
+					Score:     0,
+					Summary:   "Test source summary",
+					Tags:      "test-tag",
+					Uri:       "https://test-source-verify",
+					UriDigest: "test-source-digest-123",
+				}
+				result := testDB.Create(&newSource)
+				Expect(result.Error).ToNot(HaveOccurred())
+
+				// Create 3 claims associated with the new source
+				claim3Input := api.ClaimInput{
+					SourceUriDigest: newSource.UriDigest,
+					Summary:         "Test claim 3 summary",
+					Title:           "Test Claim 3",
+					Uri:             "https://test-claim-3",
+				}
+				digest3, err := claimRepo.PostClaim(context.TODO(), &claim3Input)
+				Expect(err).ToNot(HaveOccurred())
+
+				claim4Input := api.ClaimInput{
+					SourceUriDigest: newSource.UriDigest,
+					Summary:         "Test claim 4 summary",
+					Title:           "Test Claim 4",
+					Uri:             "https://test-claim-4",
+				}
+				digest4, err := claimRepo.PostClaim(context.TODO(), &claim4Input)
+				Expect(err).ToNot(HaveOccurred())
+
+				claim5Input := api.ClaimInput{
+					SourceUriDigest: newSource.UriDigest,
+					Summary:         "Test claim 5 summary",
+					Title:           "Test Claim 5",
+					Uri:             "https://test-claim-5",
+				}
+				digest5, err := claimRepo.PostClaim(context.TODO(), &claim5Input)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Prepare updated claims - 2 claims with different validity values
+				updatedClaims := []api.Claim{
+					{UriDigest: digest3, Validity: true},
+					{UriDigest: digest4, Validity: false},
+				}
+
+				// Call VerifyClaims
+				err = claimRepo.VerifyClaims(context.TODO(), updatedClaims)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify claim 3 - should be checked=true, validity=true
+				claim3, err := claimRepo.GetClaimByUriDigest(context.TODO(), digest3)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(claim3.Checked).To(BeTrue())
+				Expect(claim3.Validity).To(BeTrue())
+				Expect(claim3.Title).To(Equal(claim3Input.Title))
+				Expect(claim3.Summary).To(Equal(claim3Input.Summary))
+
+				// Verify claim 4 - should be checked=true, validity=false
+				claim4, err := claimRepo.GetClaimByUriDigest(context.TODO(), digest4)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(claim4.Checked).To(BeTrue())
+				Expect(claim4.Validity).To(BeFalse())
+				Expect(claim4.Title).To(Equal(claim4Input.Title))
+				Expect(claim4.Summary).To(Equal(claim4Input.Summary))
+
+				// Verify claim 5 - should remain unchanged (checked=false, validity=false)
+				claim5, err := claimRepo.GetClaimByUriDigest(context.TODO(), digest5)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(claim5.Checked).To(BeFalse())
+				Expect(claim5.Validity).To(BeFalse())
+				Expect(claim5.Title).To(Equal(claim5Input.Title))
+				Expect(claim5.Summary).To(Equal(claim5Input.Summary))
+			})
+		})
 	})
 
 	Context("Validation tests", func() {

--- a/pkg/domain/claim/claim_service.go
+++ b/pkg/domain/claim/claim_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"source-score/pkg/api"
 	"source-score/pkg/apperrors"
+	"source-score/pkg/domain/proof"
 
 	"source-score/pkg/helpers"
 	"strings"
@@ -26,6 +27,7 @@ type ClaimService interface {
 
 type claimService struct {
 	claimRepo ClaimRepository
+	proofSvc  proof.ProofService
 }
 
 var (
@@ -41,8 +43,11 @@ func init() {
 	}
 }
 
-func NewClaimService(ctx context.Context, claimRepo ClaimRepository) ClaimService {
-	return &claimService{claimRepo: claimRepo}
+func NewClaimService(ctx context.Context, claimRepo ClaimRepository, proofSvc proof.ProofService) ClaimService {
+	return &claimService{
+		claimRepo: claimRepo,
+		proofSvc:  proofSvc,
+	}
 }
 
 func (svc *claimService) GetClaims(ctx context.Context) ([]api.Claim, error) {
@@ -133,4 +138,48 @@ func (svc *claimService) VerifyClaimByUriDigest(ctx context.Context, claimVerifi
 		return fmt.Errorf("%w: %s", apperrors.ErrClaimNotFound, err.Error())
 	}
 	return err
+}
+
+func (svc *claimService) VerifyAllClaims(ctx context.Context) error {
+	claimsProofs, err := svc.proofSvc.GetProofsByClaims(ctx)
+	if err != nil {
+		return err
+	}
+
+	var updatedClaims []api.Claim
+	for claim, proofs := range claimsProofs {
+		trueCtr := 0
+		falseCtr := 0
+
+		for _, proof := range proofs {
+			if proof.SupportsClaim {
+				trueCtr += 1
+			} else {
+				falseCtr += 1
+			}
+		}
+		if trueCtr == falseCtr {
+			continue
+		}
+
+		updatedClaim, err := svc.GetClaimByUriDigest(ctx, claim)
+		if err != nil {
+			return err
+		}
+
+		updatedClaim.Checked = true
+		if trueCtr > falseCtr {
+			updatedClaim.Validity = true
+		} else {
+			updatedClaim.Validity = false
+		}
+
+		updatedClaims = append(updatedClaims, *updatedClaim)
+	}
+
+	if len(updatedClaims) > 0 {
+		
+	}
+
+	return nil
 }

--- a/pkg/domain/claim/claim_service.go
+++ b/pkg/domain/claim/claim_service.go
@@ -23,6 +23,7 @@ type ClaimService interface {
 	DeleteClaimByUriDigest(ctx context.Context, uriDigest string) error
 	PatchClaimByUriDigest(ctx context.Context, claimInput *api.ClaimPatchInput, uriDigest string) error
 	VerifyClaimByUriDigest(ctx context.Context, claimVerification *api.ClaimVerification, uriDigest string) error
+	VerifyAllClaims(ctx context.Context) error
 }
 
 type claimService struct {
@@ -178,7 +179,10 @@ func (svc *claimService) VerifyAllClaims(ctx context.Context) error {
 	}
 
 	if len(updatedClaims) > 0 {
-		
+		err = svc.claimRepo.VerifyClaims(ctx, updatedClaims)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/domain/claim/claim_service_test.go
+++ b/pkg/domain/claim/claim_service_test.go
@@ -9,6 +9,7 @@ import (
 	"source-score/pkg/apperrors"
 	"source-score/pkg/domain/claim"
 	"source-score/pkg/domain/claim/claimfakes"
+	"source-score/pkg/domain/proof/prooffakes"
 
 	"gorm.io/gorm"
 
@@ -18,7 +19,8 @@ import (
 
 var (
 	fakeClaimRepo = claimfakes.FakeClaimRepository{}
-	claimSvc      = claim.NewClaimService(context.TODO(), &fakeClaimRepo)
+	fakeProofSvc  = prooffakes.FakeProofService{}
+	claimSvc      = claim.NewClaimService(context.TODO(), &fakeClaimRepo, &fakeProofSvc)
 )
 
 var _ = Describe("Claim model service layer unit tests", Ordered, func() {

--- a/pkg/domain/claim/claim_service_test.go
+++ b/pkg/domain/claim/claim_service_test.go
@@ -177,6 +177,73 @@ var _ = Describe("Claim model service layer unit tests", Ordered, func() {
 				Expect(*argVerification.Validity).To(BeFalse())
 			})
 		})
+
+		When("Verifying all claims based on their proofs", func() {
+			It("Should verify claims with validity based on proof counts", func() {
+				claim1 := api.Claim{
+					UriDigest: claim1Digest,
+					Title:     "Claim 1",
+					Summary:   "Summary 1",
+					Checked:   false,
+					Validity:  false,
+				}
+				claim2 := api.Claim{
+					UriDigest: claim2Digest,
+					Title:     "Claim 2",
+					Summary:   "Summary 2",
+					Checked:   false,
+					Validity:  false,
+				}
+
+				proofsForClaim1 := []api.Proof{
+					{ClaimUriDigest: claim1Digest, SupportsClaim: true},
+					{ClaimUriDigest: claim1Digest, SupportsClaim: true},
+					{ClaimUriDigest: claim1Digest, SupportsClaim: true},
+					{ClaimUriDigest: claim1Digest, SupportsClaim: false},
+				}
+
+				proofsForClaim2 := []api.Proof{
+					{ClaimUriDigest: claim2Digest, SupportsClaim: true},
+					{ClaimUriDigest: claim2Digest, SupportsClaim: false},
+					{ClaimUriDigest: claim2Digest, SupportsClaim: false},
+				}
+
+				claimsProofs := map[string][]api.Proof{
+					claim1Digest: proofsForClaim1,
+					claim2Digest: proofsForClaim2,
+				}
+
+				fakeProofSvc.GetProofsByClaimsReturns(claimsProofs, nil)
+				fakeClaimRepo.GetClaimByUriDigestReturnsOnCall(2, &claim1, nil)
+				fakeClaimRepo.GetClaimByUriDigestReturnsOnCall(3, &claim2, nil)
+				fakeClaimRepo.VerifyClaimsReturns(nil)
+
+				err := claimSvc.VerifyAllClaims(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakeClaimRepo.VerifyClaimsCallCount()).To(Equal(1))
+				_, updatedClaims := fakeClaimRepo.VerifyClaimsArgsForCall(0)
+				Expect(len(updatedClaims)).To(Equal(2))
+
+				var updatedClaim1, updatedClaim2 *api.Claim
+				for i := range updatedClaims {
+					switch updatedClaims[i].UriDigest {
+					case claim1Digest:
+						updatedClaim1 = &updatedClaims[i]
+					case claim2Digest:
+						updatedClaim2 = &updatedClaims[i]
+					}
+				}
+
+				Expect(updatedClaim1).ToNot(BeNil())
+				Expect(updatedClaim1.Checked).To(BeTrue())
+				Expect(updatedClaim1.Validity).To(BeTrue())
+
+				Expect(updatedClaim2).ToNot(BeNil())
+				Expect(updatedClaim2.Checked).To(BeTrue())
+				Expect(updatedClaim2.Validity).To(BeFalse())
+			})
+		})
 	})
 
 	Context("Validation tests", func() {

--- a/pkg/domain/claim/claimfakes/fake_claim_repository.go
+++ b/pkg/domain/claim/claimfakes/fake_claim_repository.go
@@ -88,6 +88,18 @@ type FakeClaimRepository struct {
 	verifyClaimByUriDigestReturnsOnCall map[int]struct {
 		result1 error
 	}
+	VerifyClaimsStub        func(context.Context, []api.Claim) error
+	verifyClaimsMutex       sync.RWMutex
+	verifyClaimsArgsForCall []struct {
+		arg1 context.Context
+		arg2 []api.Claim
+	}
+	verifyClaimsReturns struct {
+		result1 error
+	}
+	verifyClaimsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -470,6 +482,73 @@ func (fake *FakeClaimRepository) VerifyClaimByUriDigestReturnsOnCall(i int, resu
 		})
 	}
 	fake.verifyClaimByUriDigestReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClaimRepository) VerifyClaims(arg1 context.Context, arg2 []api.Claim) error {
+	var arg2Copy []api.Claim
+	if arg2 != nil {
+		arg2Copy = make([]api.Claim, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.verifyClaimsMutex.Lock()
+	ret, specificReturn := fake.verifyClaimsReturnsOnCall[len(fake.verifyClaimsArgsForCall)]
+	fake.verifyClaimsArgsForCall = append(fake.verifyClaimsArgsForCall, struct {
+		arg1 context.Context
+		arg2 []api.Claim
+	}{arg1, arg2Copy})
+	stub := fake.VerifyClaimsStub
+	fakeReturns := fake.verifyClaimsReturns
+	fake.recordInvocation("VerifyClaims", []interface{}{arg1, arg2Copy})
+	fake.verifyClaimsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClaimRepository) VerifyClaimsCallCount() int {
+	fake.verifyClaimsMutex.RLock()
+	defer fake.verifyClaimsMutex.RUnlock()
+	return len(fake.verifyClaimsArgsForCall)
+}
+
+func (fake *FakeClaimRepository) VerifyClaimsCalls(stub func(context.Context, []api.Claim) error) {
+	fake.verifyClaimsMutex.Lock()
+	defer fake.verifyClaimsMutex.Unlock()
+	fake.VerifyClaimsStub = stub
+}
+
+func (fake *FakeClaimRepository) VerifyClaimsArgsForCall(i int) (context.Context, []api.Claim) {
+	fake.verifyClaimsMutex.RLock()
+	defer fake.verifyClaimsMutex.RUnlock()
+	argsForCall := fake.verifyClaimsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeClaimRepository) VerifyClaimsReturns(result1 error) {
+	fake.verifyClaimsMutex.Lock()
+	defer fake.verifyClaimsMutex.Unlock()
+	fake.VerifyClaimsStub = nil
+	fake.verifyClaimsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClaimRepository) VerifyClaimsReturnsOnCall(i int, result1 error) {
+	fake.verifyClaimsMutex.Lock()
+	defer fake.verifyClaimsMutex.Unlock()
+	fake.VerifyClaimsStub = nil
+	if fake.verifyClaimsReturnsOnCall == nil {
+		fake.verifyClaimsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.verifyClaimsReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/pkg/domain/claim/claimfakes/fake_claim_service.go
+++ b/pkg/domain/claim/claimfakes/fake_claim_service.go
@@ -75,6 +75,17 @@ type FakeClaimService struct {
 		result1 string
 		result2 error
 	}
+	VerifyAllClaimsStub        func(context.Context) error
+	verifyAllClaimsMutex       sync.RWMutex
+	verifyAllClaimsArgsForCall []struct {
+		arg1 context.Context
+	}
+	verifyAllClaimsReturns struct {
+		result1 error
+	}
+	verifyAllClaimsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	VerifyClaimByUriDigestStub        func(context.Context, *api.ClaimVerification, string) error
 	verifyClaimByUriDigestMutex       sync.RWMutex
 	verifyClaimByUriDigestArgsForCall []struct {
@@ -409,6 +420,67 @@ func (fake *FakeClaimService) PostClaimReturnsOnCall(i int, result1 string, resu
 		result1 string
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeClaimService) VerifyAllClaims(arg1 context.Context) error {
+	fake.verifyAllClaimsMutex.Lock()
+	ret, specificReturn := fake.verifyAllClaimsReturnsOnCall[len(fake.verifyAllClaimsArgsForCall)]
+	fake.verifyAllClaimsArgsForCall = append(fake.verifyAllClaimsArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.VerifyAllClaimsStub
+	fakeReturns := fake.verifyAllClaimsReturns
+	fake.recordInvocation("VerifyAllClaims", []interface{}{arg1})
+	fake.verifyAllClaimsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClaimService) VerifyAllClaimsCallCount() int {
+	fake.verifyAllClaimsMutex.RLock()
+	defer fake.verifyAllClaimsMutex.RUnlock()
+	return len(fake.verifyAllClaimsArgsForCall)
+}
+
+func (fake *FakeClaimService) VerifyAllClaimsCalls(stub func(context.Context) error) {
+	fake.verifyAllClaimsMutex.Lock()
+	defer fake.verifyAllClaimsMutex.Unlock()
+	fake.VerifyAllClaimsStub = stub
+}
+
+func (fake *FakeClaimService) VerifyAllClaimsArgsForCall(i int) context.Context {
+	fake.verifyAllClaimsMutex.RLock()
+	defer fake.verifyAllClaimsMutex.RUnlock()
+	argsForCall := fake.verifyAllClaimsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClaimService) VerifyAllClaimsReturns(result1 error) {
+	fake.verifyAllClaimsMutex.Lock()
+	defer fake.verifyAllClaimsMutex.Unlock()
+	fake.VerifyAllClaimsStub = nil
+	fake.verifyAllClaimsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClaimService) VerifyAllClaimsReturnsOnCall(i int, result1 error) {
+	fake.verifyAllClaimsMutex.Lock()
+	defer fake.verifyAllClaimsMutex.Unlock()
+	fake.VerifyAllClaimsStub = nil
+	if fake.verifyAllClaimsReturnsOnCall == nil {
+		fake.verifyAllClaimsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.verifyAllClaimsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeClaimService) VerifyClaimByUriDigest(arg1 context.Context, arg2 *api.ClaimVerification, arg3 string) error {

--- a/pkg/domain/proof/proof_service.go
+++ b/pkg/domain/proof/proof_service.go
@@ -20,6 +20,7 @@ type ProofService interface {
 	GetProofByUriDigest(ctx context.Context, uriDigest string) (*api.Proof, error)
 	DeleteProofByUriDigest(ctx context.Context, uriDigest string) error
 	PatchProofByUriDigest(ctx context.Context, proofInput *api.ProofPatchInput, uriDigest string) error
+	GetProofsByClaims(ctx context.Context) (map[string][]api.Proof, error)
 }
 
 type proofService struct {
@@ -105,4 +106,22 @@ func (svc *proofService) PostProof(ctx context.Context, proofInput *api.ProofInp
 	}
 
 	return svc.proofRepo.PostProof(ctx, proofInput)
+}
+
+func (svc *proofService) GetProofsByClaims(ctx context.Context) (map[string][]api.Proof, error) {
+	allProofs, err := svc.GetProofs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	claimsProofs := make(map[string][]api.Proof)
+	for _, proof := range allProofs {
+		if proofs, ok := claimsProofs[proof.ClaimUriDigest]; ok {
+			claimsProofs[proof.ClaimUriDigest] = append(proofs, proof)
+		} else {
+			claimsProofs[proof.ClaimUriDigest] = []api.Proof{proof}
+		}
+	}
+
+	return claimsProofs, nil
 }

--- a/pkg/domain/proof/proof_service_test.go
+++ b/pkg/domain/proof/proof_service_test.go
@@ -112,6 +112,40 @@ var _ = Describe("Proof model service layer unit tests", Ordered, func() {
 				Expect(*c).To(Equal(sampleProof1))
 			})
 		})
+
+		When("Getting proofs grouped by claims", func() {
+			It("Should return a map of claim uri digests to their proofs", func() {
+				// Create additional proof for a different claim
+				claimDigest2 := "a96fe15d3040685b06d0c195d54a13692a9002db148498f185babfb6a083f801"
+				proof3 := api.Proof{
+					ClaimUriDigest: claimDigest2,
+					ReviewedBy:     "ReviewerC",
+					SupportsClaim:  true,
+					Uri:            "https://sample-proof-3",
+					UriDigest:      "abc123",
+				}
+
+				allProofs := []api.Proof{sampleProof1, sampleProof2, proof3}
+				fakeProofRepo.GetProofsReturnsOnCall(1, allProofs, nil)
+
+				claimsProofs, err := proofSvc.GetProofsByClaims(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(claimsProofs).ToNot(BeNil())
+				Expect(len(claimsProofs)).To(Equal(2))
+
+				// Verify first claim has 2 proofs
+				proofs1, exists := claimsProofs[claimDigest]
+				Expect(exists).To(BeTrue())
+				Expect(len(proofs1)).To(Equal(2))
+				Expect(proofs1).To(ContainElements(sampleProof1, sampleProof2))
+
+				// Verify second claim has 1 proof
+				proofs2, exists := claimsProofs[claimDigest2]
+				Expect(exists).To(BeTrue())
+				Expect(len(proofs2)).To(Equal(1))
+				Expect(proofs2[0]).To(Equal(proof3))
+			})
+		})
 	})
 
 	Context("Proof POST validation tests", func() {

--- a/pkg/domain/proof/prooffakes/fake_proof_service.go
+++ b/pkg/domain/proof/prooffakes/fake_proof_service.go
@@ -48,6 +48,19 @@ type FakeProofService struct {
 		result1 []api.Proof
 		result2 error
 	}
+	GetProofsByClaimsStub        func(context.Context) (map[string][]api.Proof, error)
+	getProofsByClaimsMutex       sync.RWMutex
+	getProofsByClaimsArgsForCall []struct {
+		arg1 context.Context
+	}
+	getProofsByClaimsReturns struct {
+		result1 map[string][]api.Proof
+		result2 error
+	}
+	getProofsByClaimsReturnsOnCall map[int]struct {
+		result1 map[string][]api.Proof
+		result2 error
+	}
 	PatchProofByUriDigestStub        func(context.Context, *api.ProofPatchInput, string) error
 	patchProofByUriDigestMutex       sync.RWMutex
 	patchProofByUriDigestArgsForCall []struct {
@@ -266,6 +279,70 @@ func (fake *FakeProofService) GetProofsReturnsOnCall(i int, result1 []api.Proof,
 	}
 	fake.getProofsReturnsOnCall[i] = struct {
 		result1 []api.Proof
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeProofService) GetProofsByClaims(arg1 context.Context) (map[string][]api.Proof, error) {
+	fake.getProofsByClaimsMutex.Lock()
+	ret, specificReturn := fake.getProofsByClaimsReturnsOnCall[len(fake.getProofsByClaimsArgsForCall)]
+	fake.getProofsByClaimsArgsForCall = append(fake.getProofsByClaimsArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.GetProofsByClaimsStub
+	fakeReturns := fake.getProofsByClaimsReturns
+	fake.recordInvocation("GetProofsByClaims", []interface{}{arg1})
+	fake.getProofsByClaimsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeProofService) GetProofsByClaimsCallCount() int {
+	fake.getProofsByClaimsMutex.RLock()
+	defer fake.getProofsByClaimsMutex.RUnlock()
+	return len(fake.getProofsByClaimsArgsForCall)
+}
+
+func (fake *FakeProofService) GetProofsByClaimsCalls(stub func(context.Context) (map[string][]api.Proof, error)) {
+	fake.getProofsByClaimsMutex.Lock()
+	defer fake.getProofsByClaimsMutex.Unlock()
+	fake.GetProofsByClaimsStub = stub
+}
+
+func (fake *FakeProofService) GetProofsByClaimsArgsForCall(i int) context.Context {
+	fake.getProofsByClaimsMutex.RLock()
+	defer fake.getProofsByClaimsMutex.RUnlock()
+	argsForCall := fake.getProofsByClaimsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeProofService) GetProofsByClaimsReturns(result1 map[string][]api.Proof, result2 error) {
+	fake.getProofsByClaimsMutex.Lock()
+	defer fake.getProofsByClaimsMutex.Unlock()
+	fake.GetProofsByClaimsStub = nil
+	fake.getProofsByClaimsReturns = struct {
+		result1 map[string][]api.Proof
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeProofService) GetProofsByClaimsReturnsOnCall(i int, result1 map[string][]api.Proof, result2 error) {
+	fake.getProofsByClaimsMutex.Lock()
+	defer fake.getProofsByClaimsMutex.Unlock()
+	fake.GetProofsByClaimsStub = nil
+	if fake.getProofsByClaimsReturnsOnCall == nil {
+		fake.getProofsByClaimsReturnsOnCall = make(map[int]struct {
+			result1 map[string][]api.Proof
+			result2 error
+		})
+	}
+	fake.getProofsByClaimsReturnsOnCall[i] = struct {
+		result1 map[string][]api.Proof
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/handlers/claim.go
+++ b/pkg/handlers/claim.go
@@ -3,10 +3,13 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"source-score/pkg/api"
 	"source-score/pkg/apperrors"
 	"source-score/pkg/domain/claim"
+	"sync/atomic"
 
 	"github.com/gin-gonic/gin"
 )
@@ -14,6 +17,10 @@ import (
 type ClaimHandler struct {
 	claimSvc claim.ClaimService
 }
+
+var (
+	verificationJobRunning atomic.Bool
+)
 
 func NewClaimHandler(ctx context.Context, claimSvc claim.ClaimService) *ClaimHandler {
 	return &ClaimHandler{claimSvc: claimSvc}
@@ -176,17 +183,17 @@ func (ch *ClaimHandler) ValidateClaimByUriDigest(ctx *gin.Context, uriDigest str
 }
 
 func (ch *ClaimHandler) VerifyAllClaims(ctx *gin.Context) {
-	if err := ch.claimSvc.VerifyAllClaims(ctx); err != nil {
-		switch {
-		// TODO: handle error when verification is already running
-		default:
-			ctx.JSON(
-				http.StatusInternalServerError,
-				gin.H{"error": err.Error()},
-			)
-		}
+	if verificationJobRunning.CompareAndSwap(false, true) {
+		go func() {
+			defer verificationJobRunning.Store(false)
+			if err := ch.claimSvc.VerifyAllClaims(ctx); err != nil {
+				slog.Error(fmt.Sprintf("claim verification job failed with error: %v", err))
+			}
+		}()
+
+		ctx.Status(http.StatusAccepted)
 		return
 	}
 
-	ctx.Status(http.StatusAccepted)
+	ctx.Status(http.StatusConflict)
 }

--- a/pkg/handlers/claim.go
+++ b/pkg/handlers/claim.go
@@ -184,12 +184,12 @@ func (ch *ClaimHandler) ValidateClaimByUriDigest(ctx *gin.Context, uriDigest str
 
 func (ch *ClaimHandler) VerifyAllClaims(ctx *gin.Context) {
 	if verificationJobRunning.CompareAndSwap(false, true) {
-		go func() {
+		go func(c *gin.Context) {
 			defer verificationJobRunning.Store(false)
-			if err := ch.claimSvc.VerifyAllClaims(ctx); err != nil {
+			if err := ch.claimSvc.VerifyAllClaims(c); err != nil {
 				slog.Error(fmt.Sprintf("claim verification job failed with error: %v", err))
 			}
-		}()
+		}(ctx.Copy())
 
 		ctx.Status(http.StatusAccepted)
 		return

--- a/pkg/handlers/claim.go
+++ b/pkg/handlers/claim.go
@@ -174,3 +174,19 @@ func (ch *ClaimHandler) ValidateClaimByUriDigest(ctx *gin.Context, uriDigest str
 
 	ctx.Status(http.StatusNoContent)
 }
+
+func (ch *ClaimHandler) VerifyAllClaims(ctx *gin.Context) {
+	if err := ch.claimSvc.VerifyAllClaims(ctx); err != nil {
+		switch {
+		// TODO: handle error when verification is already running
+		default:
+			ctx.JSON(
+				http.StatusInternalServerError,
+				gin.H{"error": err.Error()},
+			)
+		}
+		return
+	}
+
+	ctx.Status(http.StatusAccepted)
+}

--- a/pkg/http/router.go
+++ b/pkg/http/router.go
@@ -78,6 +78,10 @@ func (r *router) PatchClaim(ctx *gin.Context, claimDigest string) {
 	r.claimHandler.PatchClaimByUriDigest(ctx, claimDigest)
 }
 
+func (r *router) VerifyAllClaims(ctx *gin.Context) {
+	r.claimHandler.VerifyAllClaims(ctx)
+}
+
 func (r *router) VerifyClaim(ctx *gin.Context, claimDigest string) {
 	// TODO: remove if individual claim verification is not required
 	// r.claimHandler.ValidateClaimByUriDigest(ctx, claimDigest)

--- a/pkg/http/router.go
+++ b/pkg/http/router.go
@@ -79,7 +79,8 @@ func (r *router) PatchClaim(ctx *gin.Context, claimDigest string) {
 }
 
 func (r *router) VerifyClaim(ctx *gin.Context, claimDigest string) {
-	r.claimHandler.ValidateClaimByUriDigest(ctx, claimDigest)
+	// TODO: remove if individual claim verification is not required
+	// r.claimHandler.ValidateClaimByUriDigest(ctx, claimDigest)
 }
 
 func (r *router) PostProof(ctx *gin.Context) {


### PR DESCRIPTION
Fixes: #76 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a POST /api/v1/claims endpoint that starts an async job to verify all claims from their proofs and bulk-update checked/validity. Implements the verification workflow requested in #76.

- **New Features**
  - Async trigger at POST /api/v1/claims; returns 202 when started and 409 if a job is already running (atomic guard).
  - Validity rule: supports > refutes → validity=true; supports < refutes → validity=false; ties are skipped; all updated claims set checked=true.
  - Proofs grouped per claim via `GetProofsByClaims` in `pkg/domain/proof`; bulk DB update via `VerifyClaims` in `pkg/domain/claim` in one query.
  - `ClaimService` now depends on `ProofService`; services wired in `cmd/app/main.go`. OpenAPI, routes, handlers, and tests updated.

- **Bug Fixes**
  - Bulk update query casts to boolean to reliably persist `validity` values.

<sup>Written for commit 0a1787712cdc6ca8961c57ca5cbc8a81c8193086. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

