### PR TITLE
feat: adds swagger ui and test instance endpoint link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,12 @@
 
 Source Score is a microservice that rates information sources based on the validity of their claims. The system evaluates sources by analyzing claims made by those sources and the supporting or refuting evidence (proofs) for each claim. Sources receive a score between 0 and 1, calculated as the ratio of valid claims to total verified claims.
 
+## API Documentation
+
+Swagger UI is available at `/swagger` when the service is running. The OpenAPI specification can be accessed at `/swagger/spec`.
+
+Check out the [test instance](https://source-score.onrender.com/swagger) and hit the endpoints ;)   
+
 ## Data Models
 
 ### Source

--- a/api/source-score.yaml
+++ b/api/source-score.yaml
@@ -2,7 +2,11 @@ openapi: 3.0.0
 info:
   title: Source Score Microservice
   description: An application to rate sources based on the validity of their claims
-  version: 0.0.1
+  version: 0.1.0
+
+servers:
+  - url: /
+    description: Current host
 
 paths:
   /ping:

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	embed "source-score"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -16,6 +17,7 @@ import (
 	"source-score/pkg/domain/claim"
 	"source-score/pkg/domain/proof"
 	"source-score/pkg/domain/source"
+	"source-score/pkg/handlers"
 	"source-score/pkg/helpers"
 	apiServer "source-score/pkg/http"
 	"source-score/pkg/logger"
@@ -76,6 +78,11 @@ func main() {
 		apiServer.NewRouter(context.Background(), srcSvc, claimSvc, proofSvc),
 		loggerOpts,
 	)
+
+	// Register Swagger UI routes
+	swaggerHandler := handlers.NewSwaggerHandler(embed.OpenAPI)
+	server.GET("/swagger", swaggerHandler.ServeUI)
+	server.GET("/swagger/spec", swaggerHandler.ServeSpec)
 
 	err := server.Run()
 	if err != nil {

--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,8 @@
+package embed
+
+import _ "embed"
+
+var (
+	//go:embed api/source-score.yaml
+	OpenAPI []byte
+)

--- a/pkg/handlers/swagger.go
+++ b/pkg/handlers/swagger.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type SwaggerHandler struct {
+	specFile []byte
+}
+
+func NewSwaggerHandler(specFile []byte) *SwaggerHandler {
+	return &SwaggerHandler{
+		specFile: specFile,
+	}
+}
+
+func (h *SwaggerHandler) ServeSpec(c *gin.Context) {
+	c.Data(http.StatusOK, "application/yaml", h.specFile)
+}
+
+func (h *SwaggerHandler) ServeUI(c *gin.Context) {
+	html := `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Source Score API Documentation</title>
+    <link
+        rel="stylesheet"
+        type="text/css"
+        href="https://unpkg.com/swagger-ui-dist@5.18.2/swagger-ui.css"
+        integrity="sha384-rcbEi6xgdPk0iWkAQzT2F3FeBJXdG+ydrawGlfHAFIZG7wU6aKbQaRewysYpmrlW"
+        crossorigin="anonymous"
+    >
+    <style>
+        html { box-sizing: border-box; overflow: -moz-scrollbars-vertical; overflow-y: scroll; }
+        *, *:before, *:after { box-sizing: inherit; }
+        body { margin:0; padding:0; }
+    </style>
+</head>
+<body>
+    <div id="swagger-ui"></div>
+    <script
+        src="https://unpkg.com/swagger-ui-dist@5.18.2/swagger-ui-bundle.js"
+        integrity="sha384-NXtFPpN61oWCuN4D42K6Zd5Rt2+uxeIT36R7kpXBuY9tLnZorzrJ4ykpqwJfgjpZ"
+        crossorigin="anonymous"
+    ></script>
+    <script
+        src="https://unpkg.com/swagger-ui-dist@5.18.2/swagger-ui-standalone-preset.js"
+        integrity="sha384-qr68CD0cvHa88PmVu7e1a58Ego4qvKtcvcLdS2a8Mo5zILI01gyIV9jVwJk7X2NU"
+        crossorigin="anonymous"
+    ></script>
+    <script>
+        window.onload = function() {
+            window.ui = SwaggerUIBundle({
+                url: "/swagger/spec",
+                dom_id: '#swagger-ui',
+                deepLinking: true,
+                presets: [
+                    SwaggerUIBundle.presets.apis,
+                    SwaggerUIStandalonePreset
+                ],
+                plugins: [
+                    SwaggerUIBundle.plugins.DownloadUrl
+                ],
+                layout: "StandaloneLayout"
+            });
+        };
+    </script>
+</body>
+</html>`
+	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(html))
+}


### PR DESCRIPTION
Fixes: #19 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an embedded Swagger UI so you can browse and try the API in the app. Adds new `/swagger` and `/swagger/spec` endpoints and documents a hosted test instance.

- **New Features**
  - Serve Swagger UI at `/swagger` and the OpenAPI YAML at `/swagger/spec`.
  - Embed the OpenAPI spec with `go:embed` to ship docs with the binary.
  - Update spec to version `0.1.0` and add a default server `/` for correct base URLs.
  - Update README with docs links and a public test instance URL.

<sup>Written for commit 2605b877864fcf54619e364f2b1ac80c618e09b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

