### PR TITLE
chore: adds docs for endpoints

### DIFF
--- a/api/source-score.yaml
+++ b/api/source-score.yaml
@@ -11,9 +11,11 @@ servers:
 paths:
   /ping:
     get:
+      summary: Health check endpoint
+      description: Returns a simple pong response to verify the service is running
       responses:
         200:
-          description: pong response
+          description: Service is healthy
           content:
             application/json:
               schema:
@@ -21,12 +23,14 @@ paths:
 
   /api/v1/sources:
     get:
+      summary: Get all sources
+      description: Retrieves a list of all registered information sources
       tags:
       - sources
       operationId: getSources
       responses:
         200:
-          description: source returned
+          description: List of sources retrieved successfully
           content:
             application/json:
               schema:
@@ -36,17 +40,21 @@ paths:
 
   /api/v1/sources/scores:
     post:
+      summary: Update all source scores
+      description: Triggers asynchronous calculation of credibility scores for all sources based on their verified claims. Returns 409 if a calculation is already in progress.
       tags:
       - sources
       operationId: updateAllScores
       responses:
         202:
-          description: score update triggered
+          description: Score update process initiated successfully
         409:
-          description: score calculation in progress
+          description: Score calculation already in progress
 
   /api/v1/source:
     post:
+      summary: Create a new source
+      description: Registers a new information source in the system. The URI must be unique and use HTTPS.
       tags:
       - source
       operationId: postSource
@@ -58,14 +66,20 @@ paths:
               $ref: '#/components/schemas/SourceInput'
       responses:
         201:
-          description: source created
+          description: Source created successfully
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateSourceResponse'
+        400:
+          description: Invalid input (missing required fields, invalid URI format, or tags contain spaces)
+        409:
+          description: Source with this URI already exists
 
   /api/v1/source/{uriDigest}:
     get:
+      summary: Get source by URI digest
+      description: Retrieves a specific source using its SHA-256 URI digest
       tags:
       - source
       operationId: getSource
@@ -73,19 +87,22 @@ paths:
       - in: path
         name: uriDigest
         required: true
+        description: SHA-256 hash of the source URI
         schema:
           type: string
       responses:
         200:
-          description: source returned
+          description: Source retrieved successfully
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Source'
         404:
-          description: source not found
+          description: Source not found
 
     patch:
+      summary: Update source fields
+      description: Partially updates a source. Only provided fields will be updated. Empty values are not allowed.
       tags:
         - source
       operationId: patchSource
@@ -93,6 +110,7 @@ paths:
       - in: path
         name: uriDigest
         required: true
+        description: SHA-256 hash of the source URI
         schema:
           type: string
       requestBody:
@@ -103,11 +121,15 @@ paths:
               $ref: '#/components/schemas/SourcePatchInput'
       responses:
         204:
-          description: source updated
+          description: Source updated successfully
+        400:
+          description: Invalid input (empty fields or tags contain spaces)
         404:
-          description: source not found
+          description: Source not found
 
     delete:
+      summary: Delete a source
+      description: Removes a source from the system
       tags:
       - source
       operationId: deleteSource
@@ -115,23 +137,25 @@ paths:
       - in: path
         name: uriDigest
         required: true
+        description: SHA-256 hash of the source URI
         schema:
           type: string
       responses:
         204:
-          description: source deleted
+          description: Source deleted successfully
         404:
-          description: source not found
+          description: Source not found
 
-  # claim paths
   /api/v1/claims:
     get:
+      summary: Get all claims
+      description: Retrieves a list of all claims across all sources
       tags:
       - claims
       operationId: getClaims
       responses:
         200:
-          description: returns all claims
+          description: List of claims retrieved successfully
           content:
             application/json:
               schema:
@@ -141,17 +165,21 @@ paths:
 
   /api/v1/claims/verify:
     post:
+      summary: Verify all claims
+      description: Triggers asynchronous verification of all claims based on their associated proofs. Claims with more supporting proofs are marked valid, those with more refuting proofs are marked invalid. Returns 409 if verification is already in progress.
       tags:
       - claims
       operationId: verifyAllClaims
       responses:
         202:
-          description: claims verification triggered
+          description: Claim verification process initiated successfully
         409:
-          description: claims verification in progress
+          description: Claim verification already in progress
 
   /api/v1/claim:
     post:
+      summary: Create a new claim
+      description: Registers a new claim associated with a source. The URI must be unique and use HTTPS.
       tags:
       - claim
       operationId: postClaim
@@ -163,10 +191,16 @@ paths:
               $ref: '#/components/schemas/ClaimInput'
       responses:
         201:
-          description: claim created
+          description: Claim created successfully
+        400:
+          description: Invalid input (missing required fields or invalid URI format)
+        404:
+          description: Source not found
 
   /api/v1/claim/{uriDigest}:
     get:
+      summary: Get claim by URI digest
+      description: Retrieves a specific claim using its SHA-256 URI digest
       tags:
       - claim
       operationId: getClaim
@@ -174,19 +208,22 @@ paths:
       - in: path
         name: uriDigest
         required: true
+        description: SHA-256 hash of the claim URI
         schema:
           type: string
       responses:
         200:
-          description: claim returned
+          description: Claim retrieved successfully
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Claim'
         404:
-          description: claim not found
+          description: Claim not found
 
     delete:
+      summary: Delete a claim
+      description: Removes a claim from the system
       tags:
       - claim
       operationId: deleteClaim
@@ -194,15 +231,18 @@ paths:
       - in: path
         name: uriDigest
         required: true
+        description: SHA-256 hash of the claim URI
         schema:
           type: string
       responses:
         204:
-          description: claim deleted
+          description: Claim deleted successfully
         404:
-          description: claim not found
+          description: Claim not found
 
     patch:
+      summary: Update claim fields
+      description: Partially updates a claim. Only provided fields (title and/or summary) will be updated. Empty values are not allowed.
       tags:
         - claim
       operationId: patchClaim
@@ -210,6 +250,7 @@ paths:
       - in: path
         name: uriDigest
         required: true
+        description: SHA-256 hash of the claim URI
         schema:
           type: string
       requestBody:
@@ -220,11 +261,15 @@ paths:
               $ref: '#/components/schemas/ClaimPatchInput'
       responses:
         204:
-          description: claim updated
+          description: Claim updated successfully
+        400:
+          description: Invalid input (empty fields)
         404:
-          description: claim not found
+          description: Claim not found
 
     post:
+      summary: Verify a single claim
+      description: Manually verifies a claim with a specified validity value (currently disabled)
       tags:
       - claim
       operationId: verifyClaim
@@ -232,6 +277,7 @@ paths:
       - in: path
         name: uriDigest
         required: true
+        description: SHA-256 hash of the claim URI
         schema:
           type: string
       requestBody:
@@ -242,19 +288,22 @@ paths:
               $ref: '#/components/schemas/ClaimVerification'
       responses:
         204:
-          description: claim verified
+          description: Claim verified successfully
+        400:
+          description: Invalid input (missing validity field)
         404:
-          description: claim not found
+          description: Claim not found
 
-  # proof paths
   /api/v1/proofs:
     get:
+      summary: Get all proofs
+      description: Retrieves a list of all proofs across all claims
       tags:
       - proofs
       operationId: getProofs
       responses:
         200:
-          description: returns all proofs
+          description: List of proofs retrieved successfully
           content:
             application/json:
               schema:
@@ -264,6 +313,8 @@ paths:
 
   /api/v1/proof:
     post:
+      summary: Create a new proof
+      description: Registers evidence that either supports or refutes a claim. The URI must be unique and use HTTPS.
       tags:
       - proof
       operationId: postProof
@@ -275,10 +326,16 @@ paths:
               $ref: '#/components/schemas/ProofInput'
       responses:
         201:
-          description: proof created
+          description: Proof created successfully
+        400:
+          description: Invalid input (missing required fields, invalid URI format, or fields contain spaces)
+        404:
+          description: Claim not found
 
   /api/v1/proof/{uriDigest}:
     get:
+      summary: Get proof by URI digest
+      description: Retrieves a specific proof using its SHA-256 URI digest
       tags:
       - proof
       operationId: getProof
@@ -286,19 +343,22 @@ paths:
       - in: path
         name: uriDigest
         required: true
+        description: SHA-256 hash of the proof URI
         schema:
           type: string
       responses:
         200:
-          description: proof returned
+          description: Proof retrieved successfully
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Proof'
         404:
-          description: proof not found
+          description: Proof not found
 
     delete:
+      summary: Delete a proof
+      description: Removes a proof from the system
       tags:
       - proof
       operationId: deleteProof
@@ -306,15 +366,18 @@ paths:
       - in: path
         name: uriDigest
         required: true
+        description: SHA-256 hash of the proof URI
         schema:
           type: string
       responses:
         204:
-          description: proof deleted
+          description: Proof deleted successfully
         404:
-          description: proof not found
+          description: Proof not found
 
     patch:
+      summary: Update proof reviewer
+      description: Updates the reviewer identifier for a proof. Empty values and spaces are not allowed.
       tags:
         - proof
       operationId: patchProof
@@ -322,6 +385,7 @@ paths:
       - in: path
         name: uriDigest
         required: true
+        description: SHA-256 hash of the proof URI
         schema:
           type: string
       requestBody:
@@ -332,9 +396,11 @@ paths:
               $ref: '#/components/schemas/ProofPatchInput'
       responses:
         204:
-          description: proof updated
+          description: Proof updated successfully
+        400:
+          description: Invalid input (empty field or contains spaces)
         404:
-          description: proof not found
+          description: Proof not found
 
 components:
   schemas:
@@ -346,9 +412,11 @@ components:
         pong:
           type: string
           example: pong
+          description: Simple response string to confirm service health
 
     SourceInput:
       type: object
+      description: Input schema for creating a new source
       required:
       - name
       - summary
@@ -357,46 +425,62 @@ components:
       properties:
         name:
           type: string
+          description: Display name of the information source
+          example: "New York Times"
           x-oapi-codegen-extra-tags:
             binding: required
             validate: nonempty
         summary:
           type: string
+          description: Brief description of the source
+          example: "American daily newspaper based in New York City"
           x-oapi-codegen-extra-tags:
             binding: required
             validate: nonempty
         tags:
           type: string
+          description: Comma-separated tags for categorization (no spaces allowed)
+          example: "news,media,journalism"
           x-oapi-codegen-extra-tags:
             validate: nonempty,nospace
             binding: required
         uri:
           type: string
+          description: Unique HTTPS URL identifying the source
+          example: "https://www.nytimes.com"
           x-oapi-codegen-extra-tags:
             validate: httpsurl
             binding: required
 
     SourcePatchInput:
       type: object
+      description: Input schema for partially updating a source
       properties:
         name:
           type: string
           nullable: true
+          description: Updated display name
+          example: "The New York Times"
           x-oapi-codegen-extra-tags:
             validate: omitnil,nonempty
         summary:
           type: string
           nullable: true
+          description: Updated description
+          example: "Leading American newspaper"
           x-oapi-codegen-extra-tags:
             validate: omitnil,nonempty
         tags:
           type: string
           nullable: true
+          description: Updated comma-separated tags (no spaces allowed)
+          example: "news,journalism,trusted"
           x-oapi-codegen-extra-tags:
             validate: omitnil,nospace,nonempty
 
     Source:
       type: object
+      description: Complete source entity with calculated credibility score
       required:
       - name
       - score
@@ -407,43 +491,59 @@ components:
       properties:
         name:
           type: string
+          description: Display name of the source
+          example: "New York Times"
           x-oapi-codegen-extra-tags:
             binding: required
         score:
           type: number
           format: double
+          description: Credibility score (0.0 to 1.0) calculated as ratio of valid to total verified claims
+          example: 0.85
           x-oapi-codegen-extra-tags:
             binding: required
         uriDigest:
           type: string
+          description: SHA-256 hash of the URI, used as primary key
+          example: "8649a4126fb4fc9a750f432b729c8477398cf28ca241403b2cd36a6dc841f441"
           x-oapi-codegen-extra-tags:
             binding: required
             gorm: primaryKey
         summary:
           type: string
+          description: Brief description of the source
+          example: "American daily newspaper"
           x-oapi-codegen-extra-tags:
             binding: required
         tags:
           type: string
+          description: Comma-separated categorization tags
+          example: "news,media,journalism"
           x-oapi-codegen-extra-tags:
             binding: required
         uri:
           type: string
+          description: Unique HTTPS URL of the source
+          example: "https://www.nytimes.com"
           x-oapi-codegen-extra-tags:
             binding: required
 
     CreateSourceResponse:
       type: object
+      description: Response after successfully creating a source
       required:
       - uriDigest
       properties:
         uriDigest:
           type: string
+          description: SHA-256 hash of the source URI
+          example: "8649a4126fb4fc9a750f432b729c8477398cf28ca241403b2cd36a6dc841f441"
           x-oapi-codegen-extra-tags:
             binding: required
 
     ClaimInput:
       type: object
+      description: Input schema for creating a new claim
       required:
       - sourceUriDigest
       - summary
@@ -452,27 +552,36 @@ components:
       properties:
         sourceUriDigest:
           type: string
+          description: SHA-256 hash of the parent source URI
+          example: "8649a4126fb4fc9a750f432b729c8477398cf28ca241403b2cd36a6dc841f441"
           x-oapi-codegen-extra-tags:
             binding: required
             validate: nonempty
         summary:
           type: string
+          description: Detailed description of the claim
+          example: "The unemployment rate decreased by 2% in Q4 2024"
           x-oapi-codegen-extra-tags:
             binding: required
             validate: nonempty
         title:
           type: string
+          description: Short title of the claim
+          example: "Unemployment Rate Decrease"
           x-oapi-codegen-extra-tags:
             binding: required
             validate: nonempty
         uri:
           type: string
+          description: Unique HTTPS URL identifying the claim
+          example: "https://www.nytimes.com/2024/unemployment-report"
           x-oapi-codegen-extra-tags:
             binding: required
             validate: httpsurl
 
     Claim:
       type: object
+      description: Complete claim entity with verification status
       required:
       - sourceUriDigest
       - summary
@@ -484,52 +593,72 @@ components:
       properties:
         sourceUriDigest:
           type: string
+          description: SHA-256 hash of the parent source URI
+          example: "8649a4126fb4fc9a750f432b729c8477398cf28ca241403b2cd36a6dc841f441"
           x-oapi-codegen-extra-tags:
             binding: required
         summary:
           type: string
+          description: Detailed description of the claim
+          example: "The unemployment rate decreased by 2% in Q4 2024"
           x-oapi-codegen-extra-tags:
             binding: required
         title:
           type: string
+          description: Short title of the claim
+          example: "Unemployment Rate Decrease"
           x-oapi-codegen-extra-tags:
             binding: required
         uri:
           type: string
+          description: Unique HTTPS URL of the claim
+          example: "https://www.nytimes.com/2024/unemployment-report"
           x-oapi-codegen-extra-tags:
             binding: required
         uriDigest:
           type: string
+          description: SHA-256 hash of the URI, used as primary key
+          example: "369d9f3047c66c2e9b5e39693d9de3664b61a36a2d77cd0484fade042350d4a1"
           x-oapi-codegen-extra-tags:
             binding: required
             gorm: primaryKey
         checked:
           type: boolean
           default: false
+          description: Indicates whether the claim has been verified
+          example: true
           x-oapi-codegen-extra-tags:
             binding: required
         validity:
           type: boolean
           default: false
+          description: Indicates whether the claim is valid (true) or invalid (false) based on proof analysis
+          example: true
           x-oapi-codegen-extra-tags:
             binding: required
 
     ClaimPatchInput:
       type: object
+      description: Input schema for partially updating a claim
       properties:
         summary:
           type: string
           nullable: true
+          description: Updated detailed description
+          example: "The unemployment rate decreased by 2.1% in Q4 2024"
           x-oapi-codegen-extra-tags:
             validate: omitnil,nonempty
         title:
           type: string
           nullable: true
+          description: Updated short title
+          example: "Q4 2024 Unemployment Decrease"
           x-oapi-codegen-extra-tags:
             validate: omitnil,nonempty
 
     ProofInput:
       type: object
+      description: Input schema for creating a new proof
       required:
       - claimUriDigest
       - reviewedBy
@@ -537,27 +666,36 @@ components:
       properties:
         claimUriDigest:
           type: string
+          description: SHA-256 hash of the claim URI being evaluated (no spaces allowed)
+          example: "369d9f3047c66c2e9b5e39693d9de3664b61a36a2d77cd0484fade042350d4a1"
           x-oapi-codegen-extra-tags:
             binding: required
             validate: nonempty,nospace
         supportsClaim:
           type: boolean
+          description: Whether this proof supports (true) or refutes (false) the claim
+          example: true
           x-oapi-codegen-extra-tags:
             binding: required
             validate: nonempty
         reviewedBy:
           type: string
+          description: Identifier of the reviewer who evaluated this proof (no spaces allowed)
+          example: "fact-checker-001"
           x-oapi-codegen-extra-tags:
             binding: required
             validate: nonempty,nospace
         uri:
           type: string
+          description: Unique HTTPS URL of the proof source
+          example: "https://bls.gov/unemployment-data-q4-2024"
           x-oapi-codegen-extra-tags:
             binding: required
             validate: httpsurl
 
     Proof:
       type: object
+      description: Complete proof entity
       required:
       - claimUriDigest
       - supportsClaim
@@ -567,42 +705,58 @@ components:
       properties:
         claimUriDigest:
           type: string
+          description: SHA-256 hash of the claim URI
+          example: "369d9f3047c66c2e9b5e39693d9de3664b61a36a2d77cd0484fade042350d4a1"
           x-oapi-codegen-extra-tags:
             binding: required
         supportsClaim:
           type: boolean
+          description: Whether this proof supports (true) or refutes (false) the claim
+          example: true
           x-oapi-codegen-extra-tags:
             binding: required
         reviewedBy:
           type: string
+          description: Identifier of the reviewer
+          example: "fact-checker-001"
           x-oapi-codegen-extra-tags:
             binding: required
         uri:
           type: string
+          description: Unique HTTPS URL of the proof source
+          example: "https://bls.gov/unemployment-data-q4-2024"
           x-oapi-codegen-extra-tags:
             binding: required
         uriDigest:
           type: string
+          description: SHA-256 hash of the URI, used as primary key
+          example: "6f2479b5249b1c27c4935da5594bc72bb0b9e59e704aea9af50780bc6178c357"
           x-oapi-codegen-extra-tags:
             binding: required
             gorm: primaryKey
 
     ProofPatchInput:
       type: object
+      description: Input schema for updating proof reviewer
       required:
       - reviewedBy
       properties:
         reviewedBy:
           type: string
+          description: Updated reviewer identifier (no spaces allowed)
+          example: "fact-checker-002"
           x-oapi-codegen-extra-tags:
             binding: required
             validate: nonempty,nospace
 
     ClaimVerification:
       type: object
+      description: Input schema for manually verifying a claim
       properties:
         validity:
           type: boolean
+          description: Whether the claim is valid (true) or invalid (false)
+          example: true
           x-oapi-codegen-extra-tags:
             binding: required
             validate: nonempty


### PR DESCRIPTION
Fixes: #81 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the Sources/Claims/Proofs API in `api/source-score.yaml` to make the OpenAPI spec clear and generator-friendly. Adds endpoint summaries/descriptions, parameter docs, error responses, and rich schema details with examples.

- New Features
  - Added summaries and detailed descriptions for all endpoints, including async jobs and 409 conflicts.
  - Documented path parameters with SHA-256 URI digest descriptions.
  - Added 400/404/409 responses where applicable with clearer meanings.
  - Expanded component schemas with descriptions, examples, and validation constraints (e.g., https URLs, no spaces).
  - Clarified partial update semantics for PATCH endpoints and input rules for POST requests.

<sup>Written for commit 1cf961ff3cf8415738538ac759bdfeec58d11dcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

