### PR TITLE
chore: logs error at handler level

### DIFF
--- a/pkg/handlers/claim.go
+++ b/pkg/handlers/claim.go
@@ -29,9 +29,10 @@ func NewClaimHandler(ctx context.Context, claimSvc claim.ClaimService) *ClaimHan
 func (ch *ClaimHandler) GetClaims(ctx *gin.Context) {
 	claims, err := ch.claimSvc.GetClaims(ctx)
 	if err != nil {
+		slog.Error("failed to get claims", "error", err)
 		ctx.JSON(
 			http.StatusInternalServerError,
-			gin.H{"error": err.Error()},
+			gin.H{"error": "internal server error"},
 		)
 		return
 	}
@@ -45,6 +46,7 @@ func (ch *ClaimHandler) GetClaims(ctx *gin.Context) {
 func (ch *ClaimHandler) PostClaim(ctx *gin.Context) {
 	claimInput := &api.ClaimInput{}
 	if err := ctx.ShouldBindJSON(claimInput); err != nil {
+		slog.Error("failed to bind claim input", "error", err)
 		ctx.JSON(
 			http.StatusBadRequest,
 			gin.H{"error": err.Error()},
@@ -61,7 +63,8 @@ func (ch *ClaimHandler) PostClaim(ctx *gin.Context) {
 				gin.H{"error": err.Error()},
 			)
 		default:
-			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			slog.Error("failed to create claim", "error", err)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 		}
 		return
 	}
@@ -79,9 +82,10 @@ func (ch *ClaimHandler) GetClaimByUriDigest(ctx *gin.Context, uriDigest string) 
 				gin.H{"error": err.Error()},
 			)
 		default:
+			slog.Error("failed to get claim", "error", err, "uriDigest", uriDigest)
 			ctx.JSON(
 				http.StatusInternalServerError,
-				gin.H{"error": err.Error()},
+				gin.H{"error": "internal server error"},
 			)
 		}
 		return
@@ -103,9 +107,10 @@ func (ch *ClaimHandler) DeleteClaimByUriDigest(ctx *gin.Context, uriDigest strin
 				gin.H{"error": err.Error()},
 			)
 		default:
+			slog.Error("failed to delete claim", "error", err, "uriDigest", uriDigest)
 			ctx.JSON(
 				http.StatusInternalServerError,
-				gin.H{"error": err.Error()},
+				gin.H{"error": "internal server error"},
 			)
 		}
 		return
@@ -117,6 +122,7 @@ func (ch *ClaimHandler) DeleteClaimByUriDigest(ctx *gin.Context, uriDigest strin
 func (ch *ClaimHandler) PatchClaimByUriDigest(ctx *gin.Context, uriDigest string) {
 	claimInput := &api.ClaimPatchInput{}
 	if err := ctx.ShouldBindJSON(claimInput); err != nil {
+		slog.Error("failed to bind claim patch input", "error", err, "uriDigest", uriDigest)
 		ctx.JSON(
 			http.StatusBadRequest,
 			gin.H{"error": err.Error()},
@@ -137,9 +143,10 @@ func (ch *ClaimHandler) PatchClaimByUriDigest(ctx *gin.Context, uriDigest string
 				gin.H{"error": err.Error()},
 			)
 		default:
+			slog.Error("failed to patch claim", "error", err, "uriDigest", uriDigest)
 			ctx.JSON(
 				http.StatusInternalServerError,
-				gin.H{"error": err.Error()},
+				gin.H{"error": "internal server error"},
 			)
 		}
 		return
@@ -151,6 +158,7 @@ func (ch *ClaimHandler) PatchClaimByUriDigest(ctx *gin.Context, uriDigest string
 func (ch *ClaimHandler) ValidateClaimByUriDigest(ctx *gin.Context, uriDigest string) {
 	claimVerification := &api.ClaimVerification{}
 	if err := ctx.ShouldBindJSON(claimVerification); err != nil {
+		slog.Error("failed to bind claim verification input", "error", err, "uriDigest", uriDigest)
 		ctx.JSON(
 			http.StatusBadRequest,
 			gin.H{"error": err.Error()},
@@ -171,9 +179,10 @@ func (ch *ClaimHandler) ValidateClaimByUriDigest(ctx *gin.Context, uriDigest str
 				gin.H{"error": err.Error()},
 			)
 		default:
+			slog.Error("failed to verify claim", "error", err, "uriDigest", uriDigest)
 			ctx.JSON(
 				http.StatusInternalServerError,
-				gin.H{"error": err.Error()},
+				gin.H{"error": "internal server error"},
 			)
 		}
 		return

--- a/pkg/handlers/proof.go
+++ b/pkg/handlers/proof.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"source-score/pkg/api"
 	"source-score/pkg/apperrors"
@@ -22,7 +23,8 @@ func NewProofHandler(ctx context.Context, proofSvc proof.ProofService) *ProofHan
 func (ph *ProofHandler) GetProofs(ctx *gin.Context) {
 	proofs, err := ph.proofSvc.GetProofs(ctx)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		slog.Error("failed to get proofs", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 		return
 	}
 
@@ -32,6 +34,7 @@ func (ph *ProofHandler) GetProofs(ctx *gin.Context) {
 func (ph *ProofHandler) PostProof(ctx *gin.Context) {
 	proofInput := &api.ProofInput{}
 	if err := ctx.ShouldBindJSON(proofInput); err != nil {
+		slog.Error("failed to bind proof input", "error", err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -42,7 +45,8 @@ func (ph *ProofHandler) PostProof(ctx *gin.Context) {
 		case errors.Is(err, apperrors.ErrInvalidProof):
 			ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		default:
-			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			slog.Error("failed to create proof", "error", err)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 		}
 		return
 	}
@@ -57,7 +61,8 @@ func (ph *ProofHandler) GetProofByUriDigest(ctx *gin.Context, uriDigest string) 
 		case errors.Is(err, apperrors.ErrProofNotFound):
 			ctx.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		default:
-			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			slog.Error("failed to get proof", "error", err, "uriDigest", uriDigest)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 		}
 		return
 	}
@@ -72,7 +77,8 @@ func (ph *ProofHandler) DeleteProofByUriDigest(ctx *gin.Context, uriDigest strin
 		case errors.Is(err, apperrors.ErrProofNotFound):
 			ctx.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		default:
-			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			slog.Error("failed to delete proof", "error", err, "uriDigest", uriDigest)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 		}
 		return
 	}
@@ -83,6 +89,7 @@ func (ph *ProofHandler) DeleteProofByUriDigest(ctx *gin.Context, uriDigest strin
 func (ph *ProofHandler) PatchProofByUriDigest(ctx *gin.Context, uriDigest string) {
 	proofInput := &api.ProofPatchInput{}
 	if err := ctx.ShouldBindJSON(proofInput); err != nil {
+		slog.Error("failed to bind proof patch input", "error", err, "uriDigest", uriDigest)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -94,7 +101,8 @@ func (ph *ProofHandler) PatchProofByUriDigest(ctx *gin.Context, uriDigest string
 		case errors.Is(err, apperrors.ErrProofNotFound):
 			ctx.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		default:
-			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			slog.Error("failed to patch proof", "error", err, "uriDigest", uriDigest)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 		}
 		return
 	}

--- a/pkg/handlers/source.go
+++ b/pkg/handlers/source.go
@@ -38,9 +38,10 @@ func (sh *SourceHandler) DeleteSourceByUriDigest(ctx *gin.Context, uriDigest str
 				gin.H{"error": err.Error()},
 			)
 		default:
+			slog.Error("failed to delete source", "error", err, "uriDigest", uriDigest)
 			ctx.JSON(
 				http.StatusInternalServerError,
-				gin.H{"error": err.Error()},
+				gin.H{"error": "internal server error"},
 			)
 		}
 		return
@@ -52,9 +53,10 @@ func (sh *SourceHandler) DeleteSourceByUriDigest(ctx *gin.Context, uriDigest str
 func (sh *SourceHandler) GetSources(ctx *gin.Context) {
 	sources, err := sh.sourceSvc.GetSources(ctx)
 	if err != nil {
+		slog.Error("failed to get sources", "error", err)
 		ctx.JSON(
 			http.StatusInternalServerError,
-			gin.H{"error": err.Error()},
+			gin.H{"error": "internal server error"},
 		)
 		return
 	}
@@ -75,9 +77,10 @@ func (sh *SourceHandler) GetSourceByUriDigest(ctx *gin.Context, uriDigest string
 				gin.H{"error": err.Error()},
 			)
 		default:
+			slog.Error("failed to get source", "error", err, "uriDigest", uriDigest)
 			ctx.JSON(
 				http.StatusInternalServerError,
-				gin.H{"error": err.Error()},
+				gin.H{"error": "internal server error"},
 			)
 		}
 		return
@@ -93,6 +96,7 @@ func (sh *SourceHandler) PostSource(ctx *gin.Context) {
 	sourceInput := &api.SourceInput{}
 	err := ctx.ShouldBindJSON(sourceInput)
 	if err != nil {
+		slog.Error("failed to bind source input", "error", err)
 		ctx.JSON(
 			http.StatusBadRequest,
 			gin.H{"error": err.Error()},
@@ -109,9 +113,10 @@ func (sh *SourceHandler) PostSource(ctx *gin.Context) {
 				gin.H{"error": err.Error()},
 			)
 		default:
+			slog.Error("failed to create source", "error", err)
 			ctx.JSON(
 				http.StatusInternalServerError,
-				gin.H{"error": err.Error()},
+				gin.H{"error": "internal server error"},
 			)
 		}
 		return
@@ -127,6 +132,7 @@ func (sh *SourceHandler) PatchSourceByUriDigest(ctx *gin.Context, uriDigest stri
 	sourceInput := &api.SourcePatchInput{}
 	err := ctx.ShouldBindJSON(sourceInput)
 	if err != nil {
+		slog.Error("failed to bind source patch input", "error", err, "uriDigest", uriDigest)
 		ctx.JSON(
 			http.StatusBadRequest,
 			gin.H{"error": err.Error()},
@@ -147,9 +153,10 @@ func (sh *SourceHandler) PatchSourceByUriDigest(ctx *gin.Context, uriDigest stri
 				gin.H{"error": err.Error()},
 			)
 		default:
+			slog.Error("failed to patch source", "error", err, "uriDigest", uriDigest)
 			ctx.JSON(
 				http.StatusInternalServerError,
-				gin.H{"error": err.Error()},
+				gin.H{"error": "internal server error"},
 			)
 		}
 		return


### PR DESCRIPTION
Fixes: #78 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured error logging across HTTP handlers and replaces raw 500s with a generic message to avoid leaking internals. Addresses #78 by improving observability and making error responses consistent.

- **Refactors**
  - Log handler errors with `log/slog` in claim, proof, and source endpoints, including JSON bind errors.
  - Add context fields to logs (e.g., `uriDigest`) for easier debugging.
  - Return {"error": "internal server error"} for 500s; keep detailed messages for 4xx.

<sup>Written for commit 445efcb49b92867acbb98ae92f526ca8ac5a6b0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

