### PR TITLE
feat: adds a middleware for api key auth

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -21,6 +21,7 @@ import (
 	"source-score/pkg/helpers"
 	apiServer "source-score/pkg/http"
 	"source-score/pkg/logger"
+	"source-score/pkg/middleware"
 )
 
 func main() {
@@ -73,6 +74,13 @@ func main() {
 	srcSvc := source.NewSourceService(context.Background(), srcRepo, claimRepo)
 
 	server := gin.Default()
+	// register middlewares
+	endpoints := server.Group("/api")
+	// secure with API key if the env var is set
+	if key, ok := os.LookupEnv("API_KEY"); ok {
+		endpoints.Use(middleware.APIKeyMiddleware(key))
+	}
+
 	api.RegisterHandlersWithOptions(
 		server,
 		apiServer.NewRouter(context.Background(), srcSvc, claimSvc, proofSvc),

--- a/pkg/middleware/apikey.go
+++ b/pkg/middleware/apikey.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func APIKeyMiddleware(validKey string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		key := c.GetHeader("X-API-Key")
+		if key != validKey {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error": "invalid or missing API key",
+			})
+			return
+		}
+		c.Next()
+	}
+}


### PR DESCRIPTION
Fixes: #85 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add API key auth middleware to protect `/api` routes when `API_KEY` is set. Requests must include the `X-API-Key` header that matches the configured key or they get a 401 JSON error.

- **New Features**
  - Added `APIKeyMiddleware` that validates `X-API-Key` and returns 401 on failure.
  - Applied the middleware to the `/api` route group when `API_KEY` is present.

- **Migration**
  - Set `API_KEY` in the environment to enable protection; leave unset to keep routes public.
  - Clients must send `X-API-Key: <your-key>` with each request.

<sup>Written for commit 154c8a0935b61b281e52b3df6b77ac9d513d132a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

