### PR TITLE
feat: adds api key auth middleware for api endpoints

### DIFF
--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -1,6 +1,7 @@
 package acceptance_test
 
 import (
+	"bytes"
 	"log"
 	"net"
 	"net/http"
@@ -31,10 +32,10 @@ const (
 )
 
 var (
-	baseUrl string
-
-	client       = &http.Client{Timeout: 10 * time.Second}
-	serverPort   = os.Getenv("PORT")
+	baseUrl        string
+	commonHeaders  = map[string]string{"X-API-Key": "test-key"}
+	client         = &http.Client{Timeout: 10 * time.Second}
+	serverPort     = os.Getenv("PORT")
 	sourceInput1 = api.SourceInput{
 		Name:    "Sample Source 1",
 		Summary: "Sample summary",
@@ -141,4 +142,32 @@ func isLocalPortOpen(port string) bool {
 	}
 	_ = conn.Close()
 	return true
+}
+
+func addCommonHeaders(req *http.Request) {
+	for key, value := range commonHeaders {
+		req.Header.Set(key, value)
+	}
+}
+
+func doRequest(method, url string, body []byte) (*http.Response, error) {
+	var req *http.Request
+	var err error
+
+	if body != nil {
+		req, err = http.NewRequest(method, url, bytes.NewBuffer(body))
+	} else {
+		req, err = http.NewRequest(method, url, nil)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	addCommonHeaders(req)
+
+	return client.Do(req)
 }

--- a/acceptance/claim_test.go
+++ b/acceptance/claim_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Claim model tests", func() {
 				srcBody, err := json.Marshal(sourceInput3)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Post(srcEndpoint, "application/json", bytes.NewBuffer(srcBody))
+				resp, err := doRequest(http.MethodPost, srcEndpoint, srcBody)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -52,7 +52,7 @@ var _ = Describe("Claim model tests", func() {
 				body1, err := json.Marshal(claim1)
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(endpoint, "application/json", bytes.NewBuffer(body1))
+				resp, err = doRequest(http.MethodPost, endpoint, body1)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -72,7 +72,7 @@ var _ = Describe("Claim model tests", func() {
 				body2, err := json.Marshal(claim2)
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(endpoint, "application/json", bytes.NewBuffer(body2))
+				resp, err = doRequest(http.MethodPost, endpoint, body2)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -87,7 +87,7 @@ var _ = Describe("Claim model tests", func() {
 
 		When("GET requests are sent to fetch claims", func() {
 			It("should return all the created claims", func() {
-				resp, err := http.Get(claimsEndpoint)
+				resp, err := doRequest(http.MethodGet, claimsEndpoint, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -110,7 +110,7 @@ var _ = Describe("Claim model tests", func() {
 				claimUrl, err := url.JoinPath(endpoint, claim1Digest)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Get(claimUrl)
+				resp, err := doRequest(http.MethodGet, claimUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -138,6 +138,7 @@ var _ = Describe("Claim model tests", func() {
 
 				req, err := http.NewRequest(http.MethodPatch, claimUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 
 				resp, err := client.Do(req)
@@ -146,7 +147,7 @@ var _ = Describe("Claim model tests", func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// verify update
-				resp, err = http.Get(claimUrl)
+				resp, err = doRequest(http.MethodGet, claimUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -171,6 +172,7 @@ var _ = Describe("Claim model tests", func() {
 
 				req, err := http.NewRequest(http.MethodPatch, claimUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 
 				resp, err := client.Do(req)
@@ -179,7 +181,7 @@ var _ = Describe("Claim model tests", func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// verify update
-				resp, err = http.Get(claimUrl)
+				resp, err = doRequest(http.MethodGet, claimUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -205,6 +207,7 @@ var _ = Describe("Claim model tests", func() {
 
 				req, err := http.NewRequest(http.MethodPatch, claimUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 
 				resp, err := client.Do(req)
@@ -213,7 +216,7 @@ var _ = Describe("Claim model tests", func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// verify update
-				resp, err = http.Get(claimUrl)
+				resp, err = doRequest(http.MethodGet, claimUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -241,13 +244,13 @@ var _ = Describe("Claim model tests", func() {
 		// 		body, err := json.Marshal(verifyBody)
 		// 		Expect(err).To(BeNil())
 
-		// 		resp, err := http.Post(claimUrl, "application/json", bytes.NewBuffer(body))
+		// 		resp, err := doRequest(http.MethodPost, claimUrl, body)
 		// 		Expect(err).To(BeNil())
 		// 		defer resp.Body.Close()
 		// 		Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 		// 		// verify the claim was updated
-		// 		resp, err = http.Get(claimUrl)
+		// 		resp, err = doRequest(http.MethodGet, claimUrl, nil)
 		// 		Expect(err).To(BeNil())
 		// 		defer resp.Body.Close()
 		// 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -267,6 +270,7 @@ var _ = Describe("Claim model tests", func() {
 
 				req, err := http.NewRequest(http.MethodDelete, claimUrl, nil)
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -274,7 +278,7 @@ var _ = Describe("Claim model tests", func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// verify deletion
-				resp, err = http.Get(claimUrl)
+				resp, err = doRequest(http.MethodGet, claimUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
@@ -293,7 +297,7 @@ var _ = Describe("Claim model tests", func() {
 				srcBody, err := json.Marshal(srcInput)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Post(srcEndpoint, "application/json", bytes.NewBuffer(srcBody))
+				resp, err := doRequest(http.MethodPost, srcEndpoint, srcBody)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -312,7 +316,7 @@ var _ = Describe("Claim model tests", func() {
 				body1, err := json.Marshal(claim1Input)
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(endpoint, "application/json", bytes.NewBuffer(body1))
+				resp, err = doRequest(http.MethodPost, endpoint, body1)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -332,7 +336,7 @@ var _ = Describe("Claim model tests", func() {
 				body2, err := json.Marshal(claim2Input)
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(endpoint, "application/json", bytes.NewBuffer(body2))
+				resp, err = doRequest(http.MethodPost, endpoint, body2)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -354,7 +358,7 @@ var _ = Describe("Claim model tests", func() {
 						Uri:            fmt.Sprintf("https://proof-claim1-support-%d", i),
 					}
 					proofBody, _ := json.Marshal(proofInput)
-					resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+					resp, err = doRequest(http.MethodPost, proofEndpoint, proofBody)
 					Expect(err).To(BeNil())
 					Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 					resp.Body.Close()
@@ -368,7 +372,7 @@ var _ = Describe("Claim model tests", func() {
 					Uri:            "https://proof-claim1-refute",
 				}
 				proofBody, _ := json.Marshal(proofInput)
-				resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+				resp, err = doRequest(http.MethodPost, proofEndpoint, proofBody)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 				resp.Body.Close()
@@ -382,7 +386,7 @@ var _ = Describe("Claim model tests", func() {
 					Uri:            "https://proof-claim2-support",
 				}
 				proofBody, _ = json.Marshal(proofInput)
-				resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+				resp, err = doRequest(http.MethodPost, proofEndpoint, proofBody)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 				resp.Body.Close()
@@ -396,7 +400,7 @@ var _ = Describe("Claim model tests", func() {
 						Uri:            fmt.Sprintf("https://proof-claim2-refute-%d", i),
 					}
 					proofBody, _ := json.Marshal(proofInput)
-					resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+					resp, err = doRequest(http.MethodPost, proofEndpoint, proofBody)
 					Expect(err).To(BeNil())
 					Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 					resp.Body.Close()
@@ -406,7 +410,7 @@ var _ = Describe("Claim model tests", func() {
 				verifyAllUrl, err := url.JoinPath(baseUrl, "/api/v1/claims/verify")
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(verifyAllUrl, "application/json", nil)
+				resp, err = doRequest(http.MethodPost, verifyAllUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
@@ -416,7 +420,7 @@ var _ = Describe("Claim model tests", func() {
 					claim1Url, err := url.JoinPath(endpoint, testClaim1Digest)
 					g.Expect(err).To(BeNil())
 
-					resp, err = http.Get(claim1Url)
+					resp, err = doRequest(http.MethodGet, claim1Url, nil)
 					g.Expect(err).To(BeNil())
 					g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -431,7 +435,7 @@ var _ = Describe("Claim model tests", func() {
 					claim2Url, err := url.JoinPath(endpoint, testClaim2Digest)
 					g.Expect(err).To(BeNil())
 
-					resp, err = http.Get(claim2Url)
+					resp, err = doRequest(http.MethodGet, claim2Url, nil)
 					g.Expect(err).To(BeNil())
 					g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -458,7 +462,7 @@ var _ = Describe("Claim model tests", func() {
 				body, err := json.Marshal(claim)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -482,7 +486,7 @@ var _ = Describe("Claim model tests", func() {
 				body, err := json.Marshal(claim)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -507,7 +511,7 @@ var _ = Describe("Claim model tests", func() {
 				body, err := json.Marshal(claim)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -525,7 +529,7 @@ var _ = Describe("Claim model tests", func() {
 				claimUrl, err := url.JoinPath(endpoint, "doesnotexist")
 				Expect(err).To(BeNil())
 
-				resp, err := http.Get(claimUrl)
+				resp, err := doRequest(http.MethodGet, claimUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
@@ -544,6 +548,7 @@ var _ = Describe("Claim model tests", func() {
 
 				req, err := http.NewRequest(http.MethodDelete, claimUrl, nil)
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -571,6 +576,7 @@ var _ = Describe("Claim model tests", func() {
 
 				req, err := http.NewRequest(http.MethodPatch, claimUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 
 				resp, err := client.Do(req)
@@ -599,6 +605,7 @@ var _ = Describe("Claim model tests", func() {
 
 				req, err := http.NewRequest(http.MethodPatch, claimUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 
 				resp, err := client.Do(req)
@@ -625,7 +632,7 @@ var _ = Describe("Claim model tests", func() {
 		// 		body, err := json.Marshal(verifyBody)
 		// 		Expect(err).To(BeNil())
 
-		// 		resp, err := http.Post(claimUrl, "application/json", bytes.NewBuffer(body))
+		// 		resp, err := doRequest(http.MethodPost, claimUrl, body)
 		// 		Expect(err).To(BeNil())
 		// 		defer resp.Body.Close()
 		// 		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -651,7 +658,7 @@ var _ = Describe("Claim model tests", func() {
 		// 		body, err := json.Marshal(verifyBody)
 		// 		Expect(err).To(BeNil())
 
-		// 		resp, err := http.Post(claimUrl, "application/json", bytes.NewBuffer(body))
+		// 		resp, err := doRequest(http.MethodPost, claimUrl, body)
 		// 		Expect(err).To(BeNil())
 		// 		defer resp.Body.Close()
 		// 		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))

--- a/acceptance/compose.yaml
+++ b/acceptance/compose.yaml
@@ -25,6 +25,7 @@ services:
     - APP_USER_PASSWORD=sourcescore
     - PG_HOST=database
     - SUPER_USER_PASSWORD=sourcescore
+    - API_KEY=test-key
     ports:
     - "8080:8080"
   adminer:

--- a/acceptance/ping_test.go
+++ b/acceptance/ping_test.go
@@ -17,7 +17,7 @@ var _ = Describe("API Tests", func() {
 
 		When("GET request is sent to /ping", func() {
 			It("should get Pong message in reponse", func() {
-				resp, err := http.Get(endpoint)
+				resp, err := doRequest(http.MethodGet, endpoint, nil)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusOK))
 

--- a/acceptance/proof_test.go
+++ b/acceptance/proof_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Proof model tests", func() {
 				srcBody, err := json.Marshal(sourceInput4)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Post(srcEndpoint, "application/json", bytes.NewBuffer(srcBody))
+				resp, err := doRequest(http.MethodPost, srcEndpoint, srcBody)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -53,7 +53,7 @@ var _ = Describe("Proof model tests", func() {
 				claimBody, err := json.Marshal(claimInput)
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(claimEndpoint, "application/json", bytes.NewBuffer(claimBody))
+				resp, err = doRequest(http.MethodPost, claimEndpoint, claimBody)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -74,7 +74,7 @@ var _ = Describe("Proof model tests", func() {
 				body1, err := json.Marshal(proof1)
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(endpoint, "application/json", bytes.NewBuffer(body1))
+				resp, err = doRequest(http.MethodPost, endpoint, body1)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -95,7 +95,7 @@ var _ = Describe("Proof model tests", func() {
 				body2, err := json.Marshal(proof2)
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(endpoint, "application/json", bytes.NewBuffer(body2))
+				resp, err = doRequest(http.MethodPost, endpoint, body2)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -109,7 +109,7 @@ var _ = Describe("Proof model tests", func() {
 
 		When("GET requests are sent to fetch proofs", func() {
 			It("should return all the created proofs and individual proof", func() {
-				resp, err := http.Get(proofsEndpoint)
+				resp, err := doRequest(http.MethodGet, proofsEndpoint, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -125,7 +125,7 @@ var _ = Describe("Proof model tests", func() {
 				proofUrl, err := url.JoinPath(endpoint, proof1Digest)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Get(proofUrl)
+				resp, err := doRequest(http.MethodGet, proofUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -150,6 +150,7 @@ var _ = Describe("Proof model tests", func() {
 
 				req, err := http.NewRequest(http.MethodPatch, proofUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 
 				resp, err := client.Do(req)
@@ -158,7 +159,7 @@ var _ = Describe("Proof model tests", func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// verify update
-				resp, err = http.Get(proofUrl)
+				resp, err = doRequest(http.MethodGet, proofUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -177,6 +178,8 @@ var _ = Describe("Proof model tests", func() {
 
 				req, err := http.NewRequest(http.MethodDelete, proofUrl, nil)
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
+
 
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -184,7 +187,7 @@ var _ = Describe("Proof model tests", func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				// verify deletion
-				resp, err = http.Get(proofUrl)
+				resp, err = doRequest(http.MethodGet, proofUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
@@ -205,7 +208,7 @@ var _ = Describe("Proof model tests", func() {
 				body, err := json.Marshal(proof)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -230,7 +233,7 @@ var _ = Describe("Proof model tests", func() {
 				body, err := json.Marshal(proof)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -255,7 +258,7 @@ var _ = Describe("Proof model tests", func() {
 				body, err := json.Marshal(proof)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -279,7 +282,7 @@ var _ = Describe("Proof model tests", func() {
 				body, err := json.Marshal(proof)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -304,7 +307,7 @@ var _ = Describe("Proof model tests", func() {
 				body, err := json.Marshal(proof)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -324,6 +327,8 @@ var _ = Describe("Proof model tests", func() {
 
 				req, err := http.NewRequest(http.MethodDelete, proofUrl, nil)
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
+
 
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -348,6 +353,7 @@ var _ = Describe("Proof model tests", func() {
 
 				req, err := http.NewRequest(http.MethodPatch, proofUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 
 				resp, err := client.Do(req)
@@ -374,6 +380,7 @@ var _ = Describe("Proof model tests", func() {
 
 				req, err := http.NewRequest(http.MethodPatch, proofUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 
 				resp, err := client.Do(req)

--- a/acceptance/source_test.go
+++ b/acceptance/source_test.go
@@ -3,7 +3,6 @@ package acceptance_test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"source-score/pkg/api"
@@ -33,11 +32,7 @@ var _ = Describe("Source model tests", func() {
 			It("should return successful response", func() {
 				var respBody api.CreateSourceResponse
 
-				resp, err := http.Post(
-					endpoint,
-					"application/json",
-					bytes.NewBuffer(body1),
-				)
+				resp, err := doRequest(http.MethodPost, endpoint, body1)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 				err = json.NewDecoder(resp.Body).Decode(&respBody)
@@ -45,11 +40,7 @@ var _ = Describe("Source model tests", func() {
 				Expect(respBody.UriDigest).To(Equal(uriDigest1))
 				resp.Body.Close()
 
-				resp, err = http.Post(
-					endpoint,
-					"application/json",
-					bytes.NewBuffer(body2),
-				)
+				resp, err = doRequest(http.MethodPost, endpoint, body2)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 				err = json.NewDecoder(resp.Body).Decode(&respBody)
@@ -63,7 +54,7 @@ var _ = Describe("Source model tests", func() {
 			It("should return the created source", func() {
 				srcUrl, err := url.JoinPath(endpoint, uriDigest1)
 				Expect(err).To(BeNil())
-				resp, err := http.Get(srcUrl)
+				resp, err := doRequest(http.MethodGet, srcUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -74,7 +65,7 @@ var _ = Describe("Source model tests", func() {
 			It("should return all sources", func() {
 				sourcesUrl, err := url.JoinPath(baseUrl, "/api/v1/sources")
 				Expect(err).To(BeNil())
-				resp, err := http.Get(sourcesUrl)
+				resp, err := doRequest(http.MethodGet, sourcesUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -102,11 +93,9 @@ var _ = Describe("Source model tests", func() {
 
 				srcUrl, err := url.JoinPath(endpoint, uriDigest1)
 				Expect(err).To(BeNil())
-				req, err := http.NewRequest(
-					http.MethodPatch,
-					srcUrl,
-					bytes.NewBuffer(reqBody))
+				req, err := http.NewRequest(http.MethodPatch, srcUrl, bytes.NewBuffer(reqBody))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -115,7 +104,7 @@ var _ = Describe("Source model tests", func() {
 
 				By("verifying source got updated")
 				var src api.Source
-				resp, err = http.Get(srcUrl)
+				resp, err = doRequest(http.MethodGet, srcUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -141,11 +130,9 @@ var _ = Describe("Source model tests", func() {
 
 				srcUrl, err := url.JoinPath(endpoint, uriDigest1)
 				Expect(err).To(BeNil())
-				req, err := http.NewRequest(
-					http.MethodPatch,
-					srcUrl,
-					bytes.NewBuffer(reqBody))
+				req, err := http.NewRequest(http.MethodPatch, srcUrl, bytes.NewBuffer(reqBody))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -154,7 +141,7 @@ var _ = Describe("Source model tests", func() {
 
 				By("verifying source got updated")
 				var src api.Source
-				resp, err = http.Get(srcUrl)
+				resp, err = doRequest(http.MethodGet, srcUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -171,12 +158,9 @@ var _ = Describe("Source model tests", func() {
 			It("should delete the created source", func() {
 				srcUrl, err := url.JoinPath(endpoint, uriDigest1)
 				Expect(err).To(BeNil())
-				req, err := http.NewRequest(
-					http.MethodDelete,
-					srcUrl,
-					nil,
-				)
+				req, err := http.NewRequest(http.MethodDelete, srcUrl, nil)
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -184,7 +168,7 @@ var _ = Describe("Source model tests", func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
 
 				By("verifying source got deleted")
-				resp, err = http.Get(srcUrl)
+				resp, err = doRequest(http.MethodGet, srcUrl, nil)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 			})
@@ -202,7 +186,7 @@ var _ = Describe("Source model tests", func() {
 				srcBody, err := json.Marshal(srcInput)
 				Expect(err).To(BeNil())
 
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(srcBody))
+				resp, err := doRequest(http.MethodPost, endpoint, srcBody)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -225,7 +209,7 @@ var _ = Describe("Source model tests", func() {
 				body1, err := json.Marshal(claim1Input)
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(claimEndpoint, "application/json", bytes.NewBuffer(body1))
+				resp, err = doRequest(http.MethodPost, claimEndpoint, body1)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -245,7 +229,7 @@ var _ = Describe("Source model tests", func() {
 				body2, err := json.Marshal(claim2Input)
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(claimEndpoint, "application/json", bytes.NewBuffer(body2))
+				resp, err = doRequest(http.MethodPost, claimEndpoint, body2)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 
@@ -264,7 +248,7 @@ var _ = Describe("Source model tests", func() {
 				body3, err := json.Marshal(claim3Input)
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(claimEndpoint, "application/json", bytes.NewBuffer(body3))
+				resp, err = doRequest(http.MethodPost, claimEndpoint, body3)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusCreated))
 				resp.Body.Close()
@@ -281,7 +265,7 @@ var _ = Describe("Source model tests", func() {
 					Uri:            "https://proof-claim1-true",
 				}
 				proofBody, _ := json.Marshal(proofInput)
-				resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+				resp, err = doRequest(http.MethodPost, proofEndpoint, proofBody)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 				resp.Body.Close()
@@ -295,7 +279,7 @@ var _ = Describe("Source model tests", func() {
 					Uri:            "https://proof-claim2-false",
 				}
 				proofBody, _ = json.Marshal(proofInput)
-				resp, err = http.Post(proofEndpoint, "application/json", bytes.NewBuffer(proofBody))
+				resp, err = doRequest(http.MethodPost, proofEndpoint, proofBody)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 				resp.Body.Close()
@@ -304,14 +288,15 @@ var _ = Describe("Source model tests", func() {
 				verifyAllUrl, err := url.JoinPath(baseUrl, "/api/v1/claims/verify")
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(verifyAllUrl, "application/json", nil)
+				// resp, err = http.Post(verifyAllUrl, "application/json", nil)
+				resp, err = doRequest(http.MethodPost, verifyAllUrl, nil)
 				Expect(err).To(BeNil())
 				resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
 
 				// Loop until verify completes (no 409)
 				for {
-					resp, err = http.Post(verifyAllUrl, "application/json", nil)
+					resp, err = doRequest(http.MethodPost, verifyAllUrl, nil)
 					Expect(err).To(BeNil())
 					resp.Body.Close()
 					if resp.StatusCode != http.StatusConflict {
@@ -324,14 +309,14 @@ var _ = Describe("Source model tests", func() {
 				updateScoresUrl, err := url.JoinPath(baseUrl, "/api/v1/sources/scores")
 				Expect(err).To(BeNil())
 
-				resp, err = http.Post(updateScoresUrl, "application/json", nil)
+				resp, err = doRequest(http.MethodPost, updateScoresUrl, nil)
 				Expect(err).To(BeNil())
 				resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
 
 				// Loop until update scores completes (no 409)
 				for {
-					resp, err = http.Post(updateScoresUrl, "application/json", nil)
+					resp, err = doRequest(http.MethodPost, updateScoresUrl, nil)
 					Expect(err).To(BeNil())
 					resp.Body.Close()
 					if resp.StatusCode != http.StatusConflict {
@@ -343,7 +328,7 @@ var _ = Describe("Source model tests", func() {
 				// Get the source and verify score is 0.5
 				srcUrl, err := url.JoinPath(endpoint, srcResp.UriDigest)
 				Expect(err).To(BeNil())
-				resp, err = http.Get(srcUrl)
+				resp, err = doRequest(http.MethodGet, srcUrl, nil)
 				Expect(err).To(BeNil())
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -352,7 +337,6 @@ var _ = Describe("Source model tests", func() {
 				Expect(err).To(BeNil())
 				resp.Body.Close()
 
-				fmt.Printf("Source score: %f\n", src.Score)
 				Expect(src.Score).To(Equal(0.5))
 			})
 		})
@@ -363,7 +347,7 @@ var _ = Describe("Source model tests", func() {
 			It("should return 404 error", func() {
 				srcUrl, err := url.JoinPath(endpoint, "invalid-digest")
 				Expect(err).To(BeNil())
-				resp, err := http.Get(srcUrl)
+				resp, err := doRequest(http.MethodGet, srcUrl, nil)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
@@ -374,12 +358,10 @@ var _ = Describe("Source model tests", func() {
 			It("should return 404 error", func() {
 				srcUrl, err := url.JoinPath(endpoint, "invalid-digest")
 				Expect(err).To(BeNil())
-				req, err := http.NewRequest(
-					http.MethodDelete,
-					srcUrl,
-					nil,
-				)
+				req, err := http.NewRequest(http.MethodDelete, srcUrl, nil)
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
+
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
@@ -390,7 +372,7 @@ var _ = Describe("Source model tests", func() {
 		When("POST request with missing required fields is sent", func() {
 			It("should return 400 Bad Request with error message", func() {
 				invalidBody := []byte(`{}`)
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(invalidBody))
+				resp, err := doRequest(http.MethodPost, endpoint, invalidBody)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -405,7 +387,7 @@ var _ = Describe("Source model tests", func() {
 		When("POST request with missing tags field is sent", func() {
 			It("should return 400 Bad Request with error message", func() {
 				invalidBody := []byte(`{"name":"valid name","summary":"valid summary","uri":"https://example.com"}`)
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(invalidBody))
+				resp, err := doRequest(http.MethodPost, endpoint, invalidBody)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -426,7 +408,7 @@ var _ = Describe("Source model tests", func() {
 					Uri:     "https://example.com",
 				}
 				body, _ := json.Marshal(invalidInput)
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -448,7 +430,7 @@ var _ = Describe("Source model tests", func() {
 					Uri:     "https://example.com",
 				}
 				body, _ := json.Marshal(invalidInput)
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -470,7 +452,7 @@ var _ = Describe("Source model tests", func() {
 					Uri:     "https://example.com",
 				}
 				body, _ := json.Marshal(invalidInput)
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -492,7 +474,7 @@ var _ = Describe("Source model tests", func() {
 					Uri:     "https://example.com",
 				}
 				body, _ := json.Marshal(invalidInput)
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -513,7 +495,7 @@ var _ = Describe("Source model tests", func() {
 					Uri:     "",
 				}
 				body, _ := json.Marshal(invalidInput)
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -535,7 +517,7 @@ var _ = Describe("Source model tests", func() {
 					Uri:     "http://example.com",
 				}
 				body, _ := json.Marshal(invalidInput)
-				resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(body))
+				resp, err := doRequest(http.MethodPost, endpoint, body)
 				Expect(err).To(BeNil())
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
@@ -558,6 +540,7 @@ var _ = Describe("Source model tests", func() {
 				Expect(err).To(BeNil())
 				req, err := http.NewRequest(http.MethodPatch, srcUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -586,6 +569,7 @@ var _ = Describe("Source model tests", func() {
 				Expect(err).To(BeNil())
 				req, err := http.NewRequest(http.MethodPatch, srcUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -614,6 +598,7 @@ var _ = Describe("Source model tests", func() {
 				Expect(err).To(BeNil())
 				req, err := http.NewRequest(http.MethodPatch, srcUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -642,6 +627,7 @@ var _ = Describe("Source model tests", func() {
 				Expect(err).To(BeNil())
 				req, err := http.NewRequest(http.MethodPatch, srcUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())
@@ -670,6 +656,7 @@ var _ = Describe("Source model tests", func() {
 				Expect(err).To(BeNil())
 				req, err := http.NewRequest(http.MethodPatch, srcUrl, bytes.NewBuffer(body))
 				Expect(err).To(BeNil())
+				addCommonHeaders(req)
 				req.Header.Set("Content-Type", "application/json")
 				resp, err := client.Do(req)
 				Expect(err).To(BeNil())

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -74,11 +74,11 @@ func main() {
 	srcSvc := source.NewSourceService(context.Background(), srcRepo, claimRepo)
 
 	server := gin.Default()
-	// register middlewares
-	endpoints := server.Group("/api")
-	// secure with API key if the env var is set
+
+	// Secure with API key if the env var is set
 	if key, ok := os.LookupEnv("API_KEY"); ok {
-		endpoints.Use(middleware.APIKeyMiddleware(key))
+		slog.Info("API Key found, securing the API")
+		server.Use(middleware.APIKeyMiddleware(key))
 	}
 
 	api.RegisterHandlersWithOptions(


### PR DESCRIPTION
Fixes: #87 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add API key authentication to all HTTP endpoints when `API_KEY` is set. Acceptance tests now send `X-API-Key` via a shared helper, and `compose.yaml` sets `API_KEY=test-key` to keep tests green.

- **New Features**
  - Apply `middleware.APIKeyMiddleware` globally when `API_KEY` is present.
  - Add test helpers (`doRequest`, `addCommonHeaders`) to include `X-API-Key` automatically.
  - Set `API_KEY=test-key` in acceptance `compose.yaml`.

- **Migration**
  - Set `API_KEY` in the environment to enable auth.
  - Send `X-API-Key: <your key>` on all requests (GET, POST, PATCH, DELETE).

<sup>Written for commit b03f1664d4c9ff3fc2f7faf8393ef79e38c47786. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

