### PR TITLE
fix: auto adds api key header to swagger requests

### DIFF
--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -33,7 +33,7 @@ const (
 
 var (
 	baseUrl        string
-	commonHeaders  = map[string]string{"X-API-Key": "test-key"}
+	commonHeaders  = map[string]string{"X-API-Key": "demo-api-key"}
 	client         = &http.Client{Timeout: 10 * time.Second}
 	serverPort     = os.Getenv("PORT")
 	sourceInput1 = api.SourceInput{

--- a/acceptance/compose.yaml
+++ b/acceptance/compose.yaml
@@ -25,7 +25,7 @@ services:
     - APP_USER_PASSWORD=sourcescore
     - PG_HOST=database
     - SUPER_USER_PASSWORD=sourcescore
-    - API_KEY=test-key
+    - API_KEY=demo-api-key
     - RATE_LIMIT_DISABLED=true
     ports:
     - "8080:8080"

--- a/api/source-score.yaml
+++ b/api/source-score.yaml
@@ -8,19 +8,10 @@ servers:
   - url: /
     description: Current host
 
-paths:
-  # /ping:
-  #   get:
-  #     summary: Health check endpoint
-  #     description: Returns a simple pong response to verify the service is running
-  #     responses:
-  #       200:
-  #         description: Service is healthy
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: '#/components/schemas/Pong'
+security:
+  - ApiKeyAuth: []
 
+paths:
   /api/v1/sources:
     get:
       summary: Get all sources
@@ -403,17 +394,13 @@ paths:
           description: Proof not found
 
 components:
-  schemas:
-    # Pong:
-    #   type: object
-    #   required:
-    #   - pong
-    #   properties:
-    #     pong:
-    #       type: string
-    #       example: pong
-    #       description: Simple response string to confirm service health
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
 
+  schemas:
     SourceInput:
       type: object
       description: Input schema for creating a new source

--- a/pkg/api/server.gen.go
+++ b/pkg/api/server.gen.go
@@ -11,6 +11,10 @@ import (
 	"github.com/oapi-codegen/runtime"
 )
 
+const (
+	ApiKeyAuthScopes = "ApiKeyAuth.Scopes"
+)
+
 // Claim Complete claim entity with verification status
 type Claim struct {
 	// Checked Indicates whether the claim has been verified
@@ -249,6 +253,8 @@ type MiddlewareFunc func(c *gin.Context)
 // PostClaim operation middleware
 func (siw *ServerInterfaceWrapper) PostClaim(c *gin.Context) {
 
+	c.Set(ApiKeyAuthScopes, []string{})
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 		if c.IsAborted() {
@@ -272,6 +278,8 @@ func (siw *ServerInterfaceWrapper) DeleteClaim(c *gin.Context) {
 		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter uriDigest: %w", err), http.StatusBadRequest)
 		return
 	}
+
+	c.Set(ApiKeyAuthScopes, []string{})
 
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
@@ -297,6 +305,8 @@ func (siw *ServerInterfaceWrapper) GetClaim(c *gin.Context) {
 		return
 	}
 
+	c.Set(ApiKeyAuthScopes, []string{})
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 		if c.IsAborted() {
@@ -320,6 +330,8 @@ func (siw *ServerInterfaceWrapper) PatchClaim(c *gin.Context) {
 		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter uriDigest: %w", err), http.StatusBadRequest)
 		return
 	}
+
+	c.Set(ApiKeyAuthScopes, []string{})
 
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
@@ -345,6 +357,8 @@ func (siw *ServerInterfaceWrapper) VerifyClaim(c *gin.Context) {
 		return
 	}
 
+	c.Set(ApiKeyAuthScopes, []string{})
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 		if c.IsAborted() {
@@ -357,6 +371,8 @@ func (siw *ServerInterfaceWrapper) VerifyClaim(c *gin.Context) {
 
 // GetClaims operation middleware
 func (siw *ServerInterfaceWrapper) GetClaims(c *gin.Context) {
+
+	c.Set(ApiKeyAuthScopes, []string{})
 
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
@@ -371,6 +387,8 @@ func (siw *ServerInterfaceWrapper) GetClaims(c *gin.Context) {
 // VerifyAllClaims operation middleware
 func (siw *ServerInterfaceWrapper) VerifyAllClaims(c *gin.Context) {
 
+	c.Set(ApiKeyAuthScopes, []string{})
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 		if c.IsAborted() {
@@ -383,6 +401,8 @@ func (siw *ServerInterfaceWrapper) VerifyAllClaims(c *gin.Context) {
 
 // PostProof operation middleware
 func (siw *ServerInterfaceWrapper) PostProof(c *gin.Context) {
+
+	c.Set(ApiKeyAuthScopes, []string{})
 
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
@@ -408,6 +428,8 @@ func (siw *ServerInterfaceWrapper) DeleteProof(c *gin.Context) {
 		return
 	}
 
+	c.Set(ApiKeyAuthScopes, []string{})
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 		if c.IsAborted() {
@@ -431,6 +453,8 @@ func (siw *ServerInterfaceWrapper) GetProof(c *gin.Context) {
 		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter uriDigest: %w", err), http.StatusBadRequest)
 		return
 	}
+
+	c.Set(ApiKeyAuthScopes, []string{})
 
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
@@ -456,6 +480,8 @@ func (siw *ServerInterfaceWrapper) PatchProof(c *gin.Context) {
 		return
 	}
 
+	c.Set(ApiKeyAuthScopes, []string{})
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 		if c.IsAborted() {
@@ -469,6 +495,8 @@ func (siw *ServerInterfaceWrapper) PatchProof(c *gin.Context) {
 // GetProofs operation middleware
 func (siw *ServerInterfaceWrapper) GetProofs(c *gin.Context) {
 
+	c.Set(ApiKeyAuthScopes, []string{})
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 		if c.IsAborted() {
@@ -481,6 +509,8 @@ func (siw *ServerInterfaceWrapper) GetProofs(c *gin.Context) {
 
 // PostSource operation middleware
 func (siw *ServerInterfaceWrapper) PostSource(c *gin.Context) {
+
+	c.Set(ApiKeyAuthScopes, []string{})
 
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
@@ -506,6 +536,8 @@ func (siw *ServerInterfaceWrapper) DeleteSource(c *gin.Context) {
 		return
 	}
 
+	c.Set(ApiKeyAuthScopes, []string{})
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 		if c.IsAborted() {
@@ -529,6 +561,8 @@ func (siw *ServerInterfaceWrapper) GetSource(c *gin.Context) {
 		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter uriDigest: %w", err), http.StatusBadRequest)
 		return
 	}
+
+	c.Set(ApiKeyAuthScopes, []string{})
 
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
@@ -554,6 +588,8 @@ func (siw *ServerInterfaceWrapper) PatchSource(c *gin.Context) {
 		return
 	}
 
+	c.Set(ApiKeyAuthScopes, []string{})
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 		if c.IsAborted() {
@@ -567,6 +603,8 @@ func (siw *ServerInterfaceWrapper) PatchSource(c *gin.Context) {
 // GetSources operation middleware
 func (siw *ServerInterfaceWrapper) GetSources(c *gin.Context) {
 
+	c.Set(ApiKeyAuthScopes, []string{})
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 		if c.IsAborted() {
@@ -579,6 +617,8 @@ func (siw *ServerInterfaceWrapper) GetSources(c *gin.Context) {
 
 // UpdateAllScores operation middleware
 func (siw *ServerInterfaceWrapper) UpdateAllScores(c *gin.Context) {
+
+	c.Set(ApiKeyAuthScopes, []string{})
 
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)

--- a/pkg/handlers/swagger.go
+++ b/pkg/handlers/swagger.go
@@ -64,7 +64,10 @@ func (h *SwaggerHandler) ServeUI(c *gin.Context) {
                 plugins: [
                     SwaggerUIBundle.plugins.DownloadUrl
                 ],
-                layout: "StandaloneLayout"
+                layout: "StandaloneLayout",
+                onComplete: function () {
+                    ui.preauthorizeApiKey("ApiKeyAuth", "demo-api-key");
+                }
             });
         };
     </script>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Swagger UI now auto-adds the `X-API-Key` header to all requests so protected endpoints work during in-browser testing. The OpenAPI spec defines `ApiKeyAuth`, and tests/envs use `demo-api-key`.

- **Bug Fixes**
  - Added `ApiKeyAuth` to OpenAPI and set it as a global security requirement.
  - Preauthorized `ApiKeyAuth` in Swagger UI with `demo-api-key`.
  - Updated acceptance tests and `compose.yaml` to use `demo-api-key`; regenerated server to set `ApiKeyAuth` scopes in request context.

<sup>Written for commit 52a93b4ad8f1fb6e58f242f930c17e18c3f5ef2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

