### PR TITLE
feat: makes supportsClaim field mandatory in while posting a proof

### DIFF
--- a/acceptance/claim_test.go
+++ b/acceptance/claim_test.go
@@ -354,7 +354,7 @@ var _ = Describe("Claim model tests", func() {
 					proofInput := api.ProofInput{
 						ClaimUriDigest: testClaim1Digest,
 						ReviewedBy:     "ReviewerA",
-						SupportsClaim:  &supports,
+						SupportsClaim:  supports,
 						Uri:            fmt.Sprintf("https://proof-claim1-support-%d", i),
 					}
 					proofBody, _ := json.Marshal(proofInput)
@@ -368,7 +368,7 @@ var _ = Describe("Claim model tests", func() {
 				proofInput := api.ProofInput{
 					ClaimUriDigest: testClaim1Digest,
 					ReviewedBy:     "ReviewerB",
-					SupportsClaim:  &supports,
+					SupportsClaim:  supports,
 					Uri:            "https://proof-claim1-refute",
 				}
 				proofBody, _ := json.Marshal(proofInput)
@@ -382,7 +382,7 @@ var _ = Describe("Claim model tests", func() {
 				proofInput = api.ProofInput{
 					ClaimUriDigest: testClaim2Digest,
 					ReviewedBy:     "ReviewerC",
-					SupportsClaim:  &supports,
+					SupportsClaim:  supports,
 					Uri:            "https://proof-claim2-support",
 				}
 				proofBody, _ = json.Marshal(proofInput)
@@ -396,7 +396,7 @@ var _ = Describe("Claim model tests", func() {
 					proofInput := api.ProofInput{
 						ClaimUriDigest: testClaim2Digest,
 						ReviewedBy:     "ReviewerD",
-						SupportsClaim:  &supports,
+						SupportsClaim:  supports,
 						Uri:            fmt.Sprintf("https://proof-claim2-refute-%d", i),
 					}
 					proofBody, _ := json.Marshal(proofInput)

--- a/acceptance/proof_test.go
+++ b/acceptance/proof_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Proof model tests", func() {
 				proof1 := api.ProofInput{
 					ClaimUriDigest: sampleProof1.ClaimUriDigest,
 					ReviewedBy:     sampleProof1.ReviewedBy,
-					SupportsClaim:  &sampleProof1.SupportsClaim,
+					SupportsClaim:  sampleProof1.SupportsClaim,
 					Uri:            sampleProof1.Uri,
 				}
 				body1, err := json.Marshal(proof1)
@@ -89,7 +89,7 @@ var _ = Describe("Proof model tests", func() {
 				proof2 := api.ProofInput{
 					ClaimUriDigest: sampleProof2.ClaimUriDigest,
 					ReviewedBy:     sampleProof2.ReviewedBy,
-					SupportsClaim:  &sampleProof2.SupportsClaim,
+					SupportsClaim:  sampleProof2.SupportsClaim,
 					Uri:            sampleProof2.Uri,
 				}
 				body2, err := json.Marshal(proof2)
@@ -202,7 +202,7 @@ var _ = Describe("Proof model tests", func() {
 				proof := api.ProofInput{
 					ClaimUriDigest: "claim digest",
 					ReviewedBy:     "ValidReviewer",
-					SupportsClaim:  &supports,
+					SupportsClaim:  supports,
 					Uri:            "https://example.com",
 				}
 				body, err := json.Marshal(proof)
@@ -227,7 +227,7 @@ var _ = Describe("Proof model tests", func() {
 				proof := api.ProofInput{
 					ClaimUriDigest: "validclaimdigest",
 					ReviewedBy:     "Reviewer Name",
-					SupportsClaim:  &supports,
+					SupportsClaim:  supports,
 					Uri:            "https://example.com",
 				}
 				body, err := json.Marshal(proof)
@@ -252,7 +252,7 @@ var _ = Describe("Proof model tests", func() {
 				proof := api.ProofInput{
 					ClaimUriDigest: "",
 					ReviewedBy:     "",
-					SupportsClaim:  &supports,
+					SupportsClaim:  supports,
 					Uri:            "https://example.com",
 				}
 				body, err := json.Marshal(proof)
@@ -301,7 +301,7 @@ var _ = Describe("Proof model tests", func() {
 				proof := api.ProofInput{
 					ClaimUriDigest: "validclaimdigest",
 					ReviewedBy:     "ValidReviewer",
-					SupportsClaim:  &supports,
+					SupportsClaim:  supports,
 					Uri:            "http://not-https.com",
 				}
 				body, err := json.Marshal(proof)

--- a/acceptance/source_test.go
+++ b/acceptance/source_test.go
@@ -261,7 +261,7 @@ var _ = Describe("Source model tests", func() {
 				proofInput := api.ProofInput{
 					ClaimUriDigest: testClaim1Digest,
 					ReviewedBy:     "ReviewerA",
-					SupportsClaim:  &supports,
+					SupportsClaim:  supports,
 					Uri:            "https://proof-claim1-true",
 				}
 				proofBody, _ := json.Marshal(proofInput)
@@ -275,7 +275,7 @@ var _ = Describe("Source model tests", func() {
 				proofInput = api.ProofInput{
 					ClaimUriDigest: testClaim2Digest,
 					ReviewedBy:     "ReviewerB",
-					SupportsClaim:  &supports,
+					SupportsClaim:  supports,
 					Uri:            "https://proof-claim2-false",
 				}
 				proofBody, _ = json.Marshal(proofInput)

--- a/api/source-score.yaml
+++ b/api/source-score.yaml
@@ -649,6 +649,7 @@ components:
       required:
       - claimUriDigest
       - reviewedBy
+      - supportsClaim
       - uri
       properties:
         claimUriDigest:

--- a/pkg/api/server.gen.go
+++ b/pkg/api/server.gen.go
@@ -102,7 +102,7 @@ type ProofInput struct {
 	ReviewedBy string `binding:"required" json:"reviewedBy" validate:"nonempty,nospace"`
 
 	// SupportsClaim Whether this proof supports (true) or refutes (false) the claim
-	SupportsClaim *bool `binding:"required" json:"supportsClaim,omitempty" validate:"nonempty"`
+	SupportsClaim bool `binding:"required" json:"supportsClaim" validate:"nonempty"`
 
 	// Uri Unique HTTPS URL of the proof source
 	Uri string `binding:"required" json:"uri" validate:"httpsurl"`

--- a/pkg/domain/proof/proof_repository.go
+++ b/pkg/domain/proof/proof_repository.go
@@ -54,7 +54,7 @@ func (pr *proofRepository) PostProof(ctx context.Context, proofInput *api.ProofI
 	proof := &api.Proof{
 		ClaimUriDigest: proofInput.ClaimUriDigest,
 		ReviewedBy:     proofInput.ReviewedBy,
-		SupportsClaim:  *proofInput.SupportsClaim,
+		SupportsClaim:  proofInput.SupportsClaim,
 		Uri:            proofInput.Uri,
 		UriDigest:      uriDigest,
 	}

--- a/pkg/domain/proof/proof_repository_test.go
+++ b/pkg/domain/proof/proof_repository_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Proof repository layer unit tests", Ordered, func() {
 				input := api.ProofInput{
 					ClaimUriDigest: sampleProof1.ClaimUriDigest,
 					ReviewedBy:     "ReviewerA",
-					SupportsClaim:  &sampleProof1.SupportsClaim,
+					SupportsClaim:  sampleProof1.SupportsClaim,
 					Uri:            sampleProof1.Uri,
 				}
 
@@ -29,7 +29,7 @@ var _ = Describe("Proof repository layer unit tests", Ordered, func() {
 				input = api.ProofInput{
 					ClaimUriDigest: sampleProof2.ClaimUriDigest,
 					ReviewedBy:     "ReviewerB",
-					SupportsClaim:  &sampleProof2.SupportsClaim,
+					SupportsClaim:  sampleProof2.SupportsClaim,
 					Uri:            sampleProof2.Uri,
 				}
 

--- a/pkg/domain/proof/proof_service_test.go
+++ b/pkg/domain/proof/proof_service_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Proof model service layer unit tests", Ordered, func() {
 				input := api.ProofInput{
 					ClaimUriDigest: sampleProof1.ClaimUriDigest,
 					ReviewedBy:     sampleProof1.ReviewedBy,
-					SupportsClaim:  &sampleProof1.SupportsClaim,
+					SupportsClaim:  sampleProof1.SupportsClaim,
 					Uri:            sampleProof1.Uri,
 				}
 
@@ -44,7 +44,7 @@ var _ = Describe("Proof model service layer unit tests", Ordered, func() {
 				input = api.ProofInput{
 					ClaimUriDigest: sampleProof2.ClaimUriDigest,
 					ReviewedBy:     sampleProof2.ReviewedBy,
-					SupportsClaim:  &sampleProof2.SupportsClaim,
+					SupportsClaim:  sampleProof2.SupportsClaim,
 					Uri:            sampleProof2.Uri,
 				}
 
@@ -155,7 +155,7 @@ var _ = Describe("Proof model service layer unit tests", Ordered, func() {
 				invalidInput := &api.ProofInput{
 					ClaimUriDigest: "claim digest",
 					ReviewedBy:     "ValidReviewer",
-					SupportsClaim:  &supports,
+					SupportsClaim:  supports,
 					Uri:            "https://example.com",
 				}
 
@@ -176,7 +176,7 @@ var _ = Describe("Proof model service layer unit tests", Ordered, func() {
 				invalidInput := &api.ProofInput{
 					ClaimUriDigest: "validclaimdigest",
 					ReviewedBy:     "Reviewer Name",
-					SupportsClaim:  &supports,
+					SupportsClaim:  supports,
 					Uri:            "https://example.com",
 				}
 
@@ -197,7 +197,7 @@ var _ = Describe("Proof model service layer unit tests", Ordered, func() {
 				invalidInput := &api.ProofInput{
 					ClaimUriDigest: "",
 					ReviewedBy:     "",
-					SupportsClaim:  &supports,
+					SupportsClaim:  supports,
 					Uri:            "https://example.com",
 				}
 
@@ -238,7 +238,7 @@ var _ = Describe("Proof model service layer unit tests", Ordered, func() {
 				invalidInput := &api.ProofInput{
 					ClaimUriDigest: "validclaimdigest",
 					ReviewedBy:     "ValidReviewer",
-					SupportsClaim:  &supports,
+					SupportsClaim:  supports,
 					Uri:            "http://not-https.com",
 				}
 


### PR DESCRIPTION
Fixes: #97 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require the proof payload to include `supportsClaim`; requests without it now fail validation. `ProofInput.supportsClaim` changed from optional (`*bool`) to required (`bool`), the OpenAPI spec marks it required, and related code/tests were updated.

- **Migration**
  - Always include `supportsClaim` (true/false) in `POST /proof` requests; null or missing is rejected.
  - Regenerate client SDKs from the updated OpenAPI spec if applicable.

<sup>Written for commit 82e613915432253ca82913cc5067799ef4b49544. Summary will update on new commits. <a href="https://cubic.dev/pr/SatyaLens/source-score/pull/99?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

