### PR TITLE
feat: updates conf to allow setting db name

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -54,7 +54,7 @@ func main() {
 		conf.Cfg.PgHost,
 		conf.AppUserName,
 		conf.Cfg.AppUserPassword,
-		conf.DbName,
+		conf.Cfg.DbName,
 	)
 	dbClient := pgsql.NewClient(context.Background(), dsn, conf.GormConfig)
 	// TODO: wrap this and call it securely

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -10,13 +10,13 @@ import (
 
 const (
 	AppUserName = "sourcescore"
-	DbName      = "sourcescore"
 )
 
 type conf struct {
 	AppUserPassword   string `env:"APP_USER_PASSWORD" yaml:"APP_USER_PASSWORD" env-required:"true"`
+	DbName            string `env:"DB_NAME" yaml:"DB_NAME" env-default:"sourcescore"`
 	PgHost            string `env:"PG_HOST" yaml:"PG_HOST" env-required:"true"`
-	Port              string `env:"PORT" yaml:"PORT"`
+	Port              string `env:"PORT" yaml:"PORT" env-default:"8080"`
 	SuperUserPassword string `env:"SUPER_USER_PASSWORD" yaml:"SUPER_USER_PASSWORD" env-required:"true"`
 }
 

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -13,6 +13,7 @@ const (
 	SamplePwd   = "sample-pwd"
 	SampleHost  = "sample-host"
 	SampleSUPwd = "super-pwd"
+	SampleDbName = "test-db"
 )
 
 var _ = Describe("Conf Tests", func() {
@@ -42,6 +43,34 @@ var _ = Describe("Conf Tests", func() {
 			Expect(conf.Cfg.PgHost).To(BeEquivalentTo("env-host"))
 			Expect(conf.Cfg.Port).To(BeEquivalentTo("8999"))
 			Expect(conf.Cfg.SuperUserPassword).To(BeEquivalentTo("user-pwd"))
+		})
+	})
+
+	When("DbName field is read", func() {
+		It("should use default value when DB_NAME environment variable is not set", func() {
+			os.Unsetenv("DOTENV_PATH")
+			os.Unsetenv("DB_NAME")
+			os.Setenv("APP_USER_PASSWORD", SamplePwd)
+			os.Setenv("PG_HOST", SampleHost)
+			os.Setenv("PORT", SamplePort)
+			os.Setenv("SUPER_USER_PASSWORD", SampleSUPwd)
+
+			conf.LoadConfig()
+
+			Expect(conf.Cfg.DbName).To(BeEquivalentTo("sourcescore"))
+		})
+
+		It("should be overwritten when DB_NAME environment variable is set", func() {
+			os.Unsetenv("DOTENV_PATH")
+			os.Setenv("DB_NAME", SampleDbName)
+			os.Setenv("APP_USER_PASSWORD", SamplePwd)
+			os.Setenv("PG_HOST", SampleHost)
+			os.Setenv("PORT", SamplePort)
+			os.Setenv("SUPER_USER_PASSWORD", SampleSUPwd)
+
+			conf.LoadConfig()
+
+			Expect(conf.Cfg.DbName).To(BeEquivalentTo(SampleDbName))
 		})
 	})
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configuration system updated to support `DB_NAME` (defaults to `sourcescore`) and `PORT` (defaults to `8080`) environment variables.

* **Tests**
  * Added test coverage for database name configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SatyaLens/source-score/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->